### PR TITLE
fix: docker pull - manifest unknown

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ docker-compose up -d
 [Docker Hub](https://hub.docker.com/r/siyueqingchen/magic-resume/)
 
 ```bash
-docker pull siyueqingchen/magic-resume
+docker pull siyueqingchen/magic-resume:main
 ```
 
 ## 📝 开源协议


### PR DESCRIPTION
$ docker pull siyueqingchen/magic-resume
Using default tag: latest
Error response from daemon: manifest for siyueqingchen/magic-resume:latest not found: manifest unknown: manifest unknown

不指定tag pull会报错