### PR TITLE
fix: project link font size not responding to typography subheaderSize

### DIFF
--- a/src/components/templates/classic/sections/ProjectSection.tsx
+++ b/src/components/templates/classic/sections/ProjectSection.tsx
@@ -38,7 +38,7 @@ const ProjectSection: React.FC<ProjectSectionProps> = ({ projects, globalSetting
                                 </div>
                                 {projectLink && !centerSubtitle && (
                                     <a href={projectLink.href} target="_blank" rel="noopener noreferrer"
-                                        className={`underline ${flexLayout ? "" : "flex-1"}`} title={projectLink.title}>
+                                        className={`underline ${flexLayout ? "" : "flex-1"}`} title={projectLink.title} style={{ fontSize: `${globalSettings?.subheaderSize || 16}px` }}>
                                         {projectLink.label}
                                     </a>
                                 )}
@@ -56,7 +56,7 @@ const ProjectSection: React.FC<ProjectSectionProps> = ({ projects, globalSetting
                                 <motion.div layout="position" className="text-subtitleFont" style={{ fontSize: `${globalSettings?.subheaderSize || 16}px` }}>{project.role}</motion.div>
                             )}
                             {projectLink && centerSubtitle && (
-                                <a href={projectLink.href} target="_blank" rel="noopener noreferrer" className="underline" title={projectLink.title}>{projectLink.label}</a>
+                                <a href={projectLink.href} target="_blank" rel="noopener noreferrer" className="underline" title={projectLink.title} style={{ fontSize: `${globalSettings?.subheaderSize || 16}px` }}>{projectLink.label}</a>
                             )}
                             {project.description && (
                                 <motion.div layout="position" className="mt-1 text-baseFont"

--- a/src/components/templates/creative/sections/ProjectSection.tsx
+++ b/src/components/templates/creative/sections/ProjectSection.tsx
@@ -38,7 +38,7 @@ const ProjectSection: React.FC<ProjectSectionProps> = ({ projects, globalSetting
                                 </div>
                                 {projectLink && !centerSubtitle && (
                                     <a href={projectLink.href} target="_blank" rel="noopener noreferrer"
-                                        className={`underline ${flexLayout ? "" : "flex-1"}`} title={projectLink.title}>
+                                        className={`underline ${flexLayout ? "" : "flex-1"}`} title={projectLink.title} style={{ fontSize: `${globalSettings?.subheaderSize || 16}px` }}>
                                         {projectLink.label}
                                     </a>
                                 )}
@@ -56,7 +56,7 @@ const ProjectSection: React.FC<ProjectSectionProps> = ({ projects, globalSetting
                                 <motion.div layout="position" className="text-subtitleFont" style={{ fontSize: `${globalSettings?.subheaderSize || 16}px` }}>{project.role}</motion.div>
                             )}
                             {projectLink && centerSubtitle && (
-                                <a href={projectLink.href} target="_blank" rel="noopener noreferrer" className="underline" title={projectLink.title}>{projectLink.label}</a>
+                                <a href={projectLink.href} target="_blank" rel="noopener noreferrer" className="underline" title={projectLink.title} style={{ fontSize: `${globalSettings?.subheaderSize || 16}px` }}>{projectLink.label}</a>
                             )}
                             {project.description && (
                                 <motion.div layout="position" className="mt-1 text-baseFont"

--- a/src/components/templates/elegant/sections/ProjectSection.tsx
+++ b/src/components/templates/elegant/sections/ProjectSection.tsx
@@ -38,7 +38,7 @@ const ProjectSection: React.FC<ProjectSectionProps> = ({ projects, globalSetting
                                 </div>
                                 {projectLink && !centerSubtitle && (
                                     <a href={projectLink.href} target="_blank" rel="noopener noreferrer"
-                                        className={`underline ${flexLayout ? "" : "flex-1"}`} title={projectLink.title}>
+                                        className={`underline ${flexLayout ? "" : "flex-1"}`} title={projectLink.title} style={{ fontSize: `${globalSettings?.subheaderSize || 16}px` }}>
                                         {projectLink.label}
                                     </a>
                                 )}
@@ -56,7 +56,7 @@ const ProjectSection: React.FC<ProjectSectionProps> = ({ projects, globalSetting
                                 <motion.div layout="position" className="text-subtitleFont" style={{ fontSize: `${globalSettings?.subheaderSize || 16}px` }}>{project.role}</motion.div>
                             )}
                             {projectLink && centerSubtitle && (
-                                <a href={projectLink.href} target="_blank" rel="noopener noreferrer" className="underline" title={projectLink.title}>{projectLink.label}</a>
+                                <a href={projectLink.href} target="_blank" rel="noopener noreferrer" className="underline" title={projectLink.title} style={{ fontSize: `${globalSettings?.subheaderSize || 16}px` }}>{projectLink.label}</a>
                             )}
                             {project.description && (
                                 <motion.div layout="position" className="mt-1 text-baseFont"

--- a/src/components/templates/left-right/sections/ProjectSection.tsx
+++ b/src/components/templates/left-right/sections/ProjectSection.tsx
@@ -38,7 +38,7 @@ const ProjectSection: React.FC<ProjectSectionProps> = ({ projects, globalSetting
                                 </div>
                                 {projectLink && !centerSubtitle && (
                                     <a href={projectLink.href} target="_blank" rel="noopener noreferrer"
-                                        className={`underline ${flexLayout ? "" : "flex-1"}`} title={projectLink.title}>
+                                        className={`underline ${flexLayout ? "" : "flex-1"}`} title={projectLink.title} style={{ fontSize: `${globalSettings?.subheaderSize || 16}px` }}>
                                         {projectLink.label}
                                     </a>
                                 )}
@@ -56,7 +56,7 @@ const ProjectSection: React.FC<ProjectSectionProps> = ({ projects, globalSetting
                                 <motion.div layout="position" className="text-subtitleFont" style={{ fontSize: `${globalSettings?.subheaderSize || 16}px` }}>{project.role}</motion.div>
                             )}
                             {projectLink && centerSubtitle && (
-                                <a href={projectLink.href} target="_blank" rel="noopener noreferrer" className="underline" title={projectLink.title}>{projectLink.label}</a>
+                                <a href={projectLink.href} target="_blank" rel="noopener noreferrer" className="underline" title={projectLink.title} style={{ fontSize: `${globalSettings?.subheaderSize || 16}px` }}>{projectLink.label}</a>
                             )}
                             {project.description && (
                                 <motion.div layout="position" className="mt-1 text-baseFont"

--- a/src/components/templates/minimalist/sections/ProjectSection.tsx
+++ b/src/components/templates/minimalist/sections/ProjectSection.tsx
@@ -38,7 +38,7 @@ const ProjectSection: React.FC<ProjectSectionProps> = ({ projects, globalSetting
                                 </div>
                                 {projectLink && !centerSubtitle && (
                                     <a href={projectLink.href} target="_blank" rel="noopener noreferrer"
-                                        className={`underline ${flexLayout ? "" : "flex-1"}`} title={projectLink.title}>
+                                        className={`underline ${flexLayout ? "" : "flex-1"}`} title={projectLink.title} style={{ fontSize: `${globalSettings?.subheaderSize || 16}px` }}>
                                         {projectLink.label}
                                     </a>
                                 )}
@@ -56,7 +56,7 @@ const ProjectSection: React.FC<ProjectSectionProps> = ({ projects, globalSetting
                                 <motion.div layout="position" className="text-subtitleFont" style={{ fontSize: `${globalSettings?.subheaderSize || 16}px` }}>{project.role}</motion.div>
                             )}
                             {projectLink && centerSubtitle && (
-                                <a href={projectLink.href} target="_blank" rel="noopener noreferrer" className="underline" title={projectLink.title}>{projectLink.label}</a>
+                                <a href={projectLink.href} target="_blank" rel="noopener noreferrer" className="underline" title={projectLink.title} style={{ fontSize: `${globalSettings?.subheaderSize || 16}px` }}>{projectLink.label}</a>
                             )}
                             {project.description && (
                                 <motion.div layout="position" className="mt-1 text-baseFont"

--- a/src/components/templates/modern/sections/ProjectSection.tsx
+++ b/src/components/templates/modern/sections/ProjectSection.tsx
@@ -38,7 +38,7 @@ const ProjectSection: React.FC<ProjectSectionProps> = ({ projects, globalSetting
                                 </div>
                                 {projectLink && !centerSubtitle && (
                                     <a href={projectLink.href} target="_blank" rel="noopener noreferrer"
-                                        className={cn("underline truncate shrink", flexLayout ? "" : "flex-1")} title={projectLink.title}>
+                                        className={cn("underline truncate shrink", flexLayout ? "" : "flex-1")} title={projectLink.title} style={{ fontSize: `${globalSettings?.subheaderSize || 16}px` }}>
                                         {projectLink.label}
                                     </a>
                                 )}
@@ -56,7 +56,7 @@ const ProjectSection: React.FC<ProjectSectionProps> = ({ projects, globalSetting
                                 <motion.div layout="position" className="text-subtitleFont" style={{ fontSize: `${globalSettings?.subheaderSize || 16}px` }}>{project.role}</motion.div>
                             )}
                             {projectLink && centerSubtitle && (
-                                <a href={projectLink.href} target="_blank" rel="noopener noreferrer" className="underline" title={projectLink.title}>{projectLink.label}</a>
+                                <a href={projectLink.href} target="_blank" rel="noopener noreferrer" className="underline" title={projectLink.title} style={{ fontSize: `${globalSettings?.subheaderSize || 16}px` }}>{projectLink.label}</a>
                             )}
                             {project.description && (
                                 <motion.div layout="position" className="mt-1 text-baseFont"

--- a/src/components/templates/timeline/sections/ProjectSection.tsx
+++ b/src/components/templates/timeline/sections/ProjectSection.tsx
@@ -38,7 +38,7 @@ const ProjectSection: React.FC<ProjectSectionProps> = ({ projects, globalSetting
                                 </div>
                                 {projectLink && !centerSubtitle && (
                                     <a href={projectLink.href} target="_blank" rel="noopener noreferrer"
-                                        className={`underline ${flexLayout ? "" : "flex-1"}`} title={projectLink.title}>
+                                        className={`underline ${flexLayout ? "" : "flex-1"}`} title={projectLink.title} style={{ fontSize: `${globalSettings?.subheaderSize || 16}px` }}>
                                         {projectLink.label}
                                     </a>
                                 )}
@@ -56,7 +56,7 @@ const ProjectSection: React.FC<ProjectSectionProps> = ({ projects, globalSetting
                                 <motion.div layout="position" className="text-subtitleFont" style={{ fontSize: `${globalSettings?.subheaderSize || 16}px` }}>{project.role}</motion.div>
                             )}
                             {projectLink && centerSubtitle && (
-                                <a href={projectLink.href} target="_blank" rel="noopener noreferrer" className="underline" title={projectLink.title}>{projectLink.label}</a>
+                                <a href={projectLink.href} target="_blank" rel="noopener noreferrer" className="underline" title={projectLink.title} style={{ fontSize: `${globalSettings?.subheaderSize || 16}px` }}>{projectLink.label}</a>
                             )}
                             {project.description && (
                                 <motion.div layout="position" className="mt-1 text-baseFont"


### PR DESCRIPTION
Closes #343

This PR binds the project link text font size to `globalSettings?.subheaderSize` across all affected templates.

### Affected templates
- classic
- modern
- creative
- elegant
- minimalist
- left-right
- timeline

The `editorial` template was not affected because its link inherits font size from the parent container.