### PR TITLE
Feat/long page export

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "framer-motion": "^11.11.10",
     "html2canvas": "^1.4.1",
     "html2pdf.js": "^0.10.2",
+    "jspdf": "2.5.2",
     "lodash": "^4.17.21",
     "lucide-react": "^0.379.0",
     "mark.js": "^8.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       html2pdf.js:
         specifier: ^0.10.2
         version: 0.10.2
+      jspdf:
+        specifier: 2.5.2
+        version: 2.5.2
       lodash:
         specifier: ^4.17.21
         version: 4.17.21

--- a/src/components/preview/PreviewDock.tsx
+++ b/src/components/preview/PreviewDock.tsx
@@ -11,7 +11,8 @@ import {
   FileJson,
   Loader2,
   Eye,
-  FileText
+  FileText,
+  EyeOff
 } from "lucide-react";
 import { RiMarkdownLine } from "@remixicon/react";
 import { toast } from "sonner";
@@ -106,6 +107,7 @@ const PreviewDock = ({
 
   const { duplicateResume, setActiveResume, activeResumeId, activeResume, updateGlobalSettings } = useResumeStore();
   const { globalSettings = {} } = activeResume || {};
+  const pageBreakLinesVisible = globalSettings?.pageBreakLinesVisible !== false;
 
   const { checkConfiguration } = useAIConfiguration();
 
@@ -236,6 +238,39 @@ const PreviewDock = ({
                   </TooltipTrigger>
                   <TooltipContent side="left" sideOffset={10}>
                     <p>{t("autoOnePage.tooltip")}</p>
+                  </TooltipContent>
+                </Tooltip>
+              </DockIcon>
+              <DockIcon>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div
+                      className={cn(
+                        "flex cursor-pointer h-7 w-7 items-center justify-center rounded-lg",
+                        "hover:bg-gray-100/50 dark:hover:bg-neutral-800/50",
+                        "transition-all duration-200",
+                        !pageBreakLinesVisible && [
+                          "bg-primary text-primary-foreground",
+                          "hover:bg-primary/90 dark:hover:bg-primary/90",
+                          "shadow-sm"
+                        ]
+                      )}
+                      onClick={() => {
+                        updateGlobalSettings({
+                          pageBreakLinesVisible: !pageBreakLinesVisible
+                        });
+                        toast.success(
+                          pageBreakLinesVisible
+                            ? t("pageBreakLine.hidden")
+                            : t("pageBreakLine.visible")
+                        );
+                      }}
+                    >
+                      <EyeOff className="h-4 w-4" />
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="left" sideOffset={10}>
+                    <p>{t("pageBreakLine.tooltip")}</p>
                   </TooltipContent>
                 </Tooltip>
               </DockIcon>

--- a/src/components/preview/index.tsx
+++ b/src/components/preview/index.tsx
@@ -134,6 +134,8 @@ const PreviewPanel = React.forwardRef<HTMLDivElement, PreviewPanelProps>(
 
     const pagePadding = activeResume?.globalSettings?.pagePadding || 0;
     const autoOnePageEnabled = activeResume?.globalSettings?.autoOnePage || false;
+    const pageBreakLinesVisible =
+      activeResume?.globalSettings?.pageBreakLinesVisible !== false;
 
     const { scaleFactor, isScaled, cannotFit } = useAutoOnePage({
       contentHeight,
@@ -271,7 +273,7 @@ const PreviewPanel = React.forwardRef<HTMLDivElement, PreviewPanelProps>(
               }
             `}</style>
               <ResumeTemplateComponent data={activeResume} template={template} />
-              {contentHeight > 0 && (
+              {pageBreakLinesVisible && contentHeight > 0 && (
                 <>
                   <div key={`page-breaks-container-${contentHeight}`}>
                     {Array.from(

--- a/src/components/shared/GlassIcons.tsx
+++ b/src/components/shared/GlassIcons.tsx
@@ -116,3 +116,28 @@ export const MarkdownGlassIcon = ({ className, isLoading }: GlassIconProps) => (
     </path>
   </svg>
 );
+
+export const ImageGlassIcon = ({ className, isLoading }: GlassIconProps) => (
+  <svg viewBox="0 0 100 100" fill="none" className={className}>
+    <defs>
+      <filter id="img-glow"><feGaussianBlur stdDeviation="8" /></filter>
+      <linearGradient id="img-glass" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0%" stopColor="#ffffff" stopOpacity="0.68" />
+        <stop offset="100%" stopColor="#ffffff" stopOpacity="0.08" />
+      </linearGradient>
+      <linearGradient id="img-border" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0%" stopColor="#ffffff" stopOpacity="0.9" />
+        <stop offset="100%" stopColor="#ffffff" stopOpacity="0.18" />
+      </linearGradient>
+    </defs>
+    <rect x="20" y="18" width="56" height="64" rx="10" fill="#0f766e" filter="url(#img-glow)" opacity="0.62" />
+    <rect x="18" y="16" width="60" height="68" rx="12" fill="#0f766e" />
+    <rect x="12" y="10" width="68" height="74" rx="14" fill="url(#img-glass)" stroke="url(#img-border)" strokeWidth="1.5" />
+    <circle cx="35" cy="31" r="5" fill="#ffffff" opacity="0.9" />
+    <path d="M22 67 L38 49 L48 59 L59 45 L74 67" stroke="#ffffff" strokeWidth="4" strokeLinecap="round" strokeLinejoin="round" opacity="0.95" />
+    <path d="M23 70H75" stroke="#ffffff" strokeWidth="3" strokeLinecap="round" opacity="0.28" />
+    <rect x="26" y="73" width={isLoading ? "18" : "24"} height="4" rx="2" fill="#ffffff" opacity="0.72">
+      {isLoading && <animate attributeName="width" values="14;26;14" dur="1.2s" repeatCount="indefinite" />}
+    </rect>
+  </svg>
+);

--- a/src/components/shared/PdfExport.tsx
+++ b/src/components/shared/PdfExport.tsx
@@ -3,7 +3,12 @@ import { useTranslations } from "@/i18n/compat/client";
 import { Download, Loader2, ChevronDown, ShieldCheck } from "lucide-react";
 import { useResumeStore } from "@/store/useResumeStore";
 import { Button } from "@/components/ui/button";
-import { exportResumeAsJson, exportResumeAsMarkdown, exportToPdf } from "@/utils/export";
+import {
+  exportResumeAsJson,
+  exportResumeAsMarkdown,
+  exportToLongPagePdf,
+  exportToPdf
+} from "@/utils/export";
 import { exportResumeToBrowserPrint } from "@/utils/print";
 import { cn } from "@/lib/utils";
 import {
@@ -82,6 +87,7 @@ const ExportCard = ({
 const PdfExport = ({ children }: { children?: React.ReactNode }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
+  const [isExportingLongPage, setIsExportingLongPage] = useState(false);
   const [isPrinting, setIsPrinting] = useState(false);
   const [isExportingJson, setIsExportingJson] = useState(false);
   const [isExportingMarkdown, setIsExportingMarkdown] = useState(false);
@@ -98,6 +104,19 @@ const PdfExport = ({ children }: { children?: React.ReactNode }) => {
       fontFamily: globalSettings?.fontFamily,
       onStart: () => setIsExporting(true),
       onEnd: () => setIsExporting(false),
+      successMessage: t("toast.success"),
+      errorMessage: t("toast.error")
+    });
+  };
+
+  const handleLongPageExport = async () => {
+    await exportToLongPagePdf({
+      elementId: "resume-preview",
+      title: title || "resume",
+      pagePadding: globalSettings?.pagePadding || 0,
+      fontFamily: globalSettings?.fontFamily,
+      onStart: () => setIsExportingLongPage(true),
+      onEnd: () => setIsExportingLongPage(false),
       successMessage: t("toast.success"),
       errorMessage: t("toast.error")
     });
@@ -156,9 +175,16 @@ const PdfExport = ({ children }: { children?: React.ReactNode }) => {
     }
   };
 
-  const isLoading = isExporting || isExportingJson || isExportingMarkdown || isPrinting;
+  const isLoading =
+    isExporting ||
+    isExportingLongPage ||
+    isExportingJson ||
+    isExportingMarkdown ||
+    isPrinting;
   const loadingText = isExporting
     ? t("button.exporting")
+    : isExportingLongPage
+      ? t("button.exporting")
     : isExportingJson
       ? t("button.exportingJson")
       : isExportingMarkdown
@@ -221,6 +247,15 @@ const PdfExport = ({ children }: { children?: React.ReactNode }) => {
               onClick={handleExport}
               bgGradientClass="from-rose-500/10 dark:from-rose-500/20"
               hoverBorderClass="hover:border-rose-500/40 hover:ring-1 hover:ring-rose-500/20"
+            />
+            <ExportCard
+              icon={PdfGlassIcon}
+              title={t("button.exportLongPagePdf")}
+              description={t("modal.longPagePdfDesc")}
+              isLoading={isExportingLongPage}
+              onClick={handleLongPageExport}
+              bgGradientClass="from-violet-500/10 dark:from-violet-500/20"
+              hoverBorderClass="hover:border-violet-500/40 hover:ring-1 hover:ring-violet-500/20"
             />
             <ExportCard
               icon={PrintGlassIcon}

--- a/src/components/shared/PdfExport.tsx
+++ b/src/components/shared/PdfExport.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import {
   exportResumeAsJson,
   exportResumeAsMarkdown,
+  exportToLongPageImage,
   exportToLongPagePdf,
   exportToPdf
 } from "@/utils/export";
@@ -22,6 +23,7 @@ import {
 
 import {
   PdfGlassIcon,
+  ImageGlassIcon,
   PrintGlassIcon,
   JsonGlassIcon,
   MarkdownGlassIcon,
@@ -34,6 +36,7 @@ const ExportCard = ({
   description,
   onClick,
   isLoading,
+  isDisabled,
   bgGradientClass,
   hoverBorderClass,
 }: {
@@ -42,17 +45,20 @@ const ExportCard = ({
   description: string,
   onClick: () => void,
   isLoading: boolean,
+  isDisabled?: boolean,
   bgGradientClass?: string,
   hoverBorderClass?: string,
 }) => {
+  const disabled = isLoading || isDisabled;
+
   return (
     <div
       onClick={() => {
-        if (!isLoading) onClick();
+        if (!disabled) onClick();
       }}
       className={cn(
         "group relative flex flex-col justify-center overflow-hidden p-6 pl-[136px] min-h-[130px] rounded-3xl border border-border/50 bg-card text-card-foreground shadow-sm transition-all duration-500",
-        isLoading ? "opacity-70 cursor-not-allowed" : cn("cursor-pointer hover:shadow-2xl active:scale-[0.98] hover:-translate-y-1 hover:bg-muted/10", hoverBorderClass)
+        disabled ? "opacity-70 cursor-not-allowed" : cn("cursor-pointer hover:shadow-2xl active:scale-[0.98] hover:-translate-y-1 hover:bg-muted/10", hoverBorderClass)
       )}
     >
       {/* 顶部内发光高光，增加卡片立体感 */}
@@ -61,14 +67,14 @@ const ExportCard = ({
       {/* 底部环境光晕，让图标色渗入背景 */}
       <div className={cn(
         "absolute inset-0 pointer-events-none transition-opacity duration-500 bg-gradient-to-r to-transparent",
-        isLoading ? "opacity-50" : "opacity-0 group-hover:opacity-100",
+        disabled ? "opacity-50" : "opacity-0 group-hover:opacity-100",
         bgGradientClass
       )} />
 
       {/* 调整后的图标层：完全收入卡片内部，尺寸克制 */}
       <div className={cn(
         "absolute left-6 top-1/2 -translate-y-1/2 w-24 h-24 transition-transform duration-500 will-change-transform drop-shadow-xl pointer-events-none",
-        isLoading ? "-rotate-6 scale-[1.05] opacity-80" : "-rotate-6 group-hover:scale-[1.1] group-hover:-rotate-3"
+        disabled ? "-rotate-6 scale-[1.05] opacity-80" : "-rotate-6 group-hover:scale-[1.1] group-hover:-rotate-3"
       )}>
         <Icon className="w-full h-full object-contain" isLoading={isLoading} />
       </div>
@@ -88,6 +94,7 @@ const PdfExport = ({ children }: { children?: React.ReactNode }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
   const [isExportingLongPage, setIsExportingLongPage] = useState(false);
+  const [isExportingImage, setIsExportingImage] = useState(false);
   const [isPrinting, setIsPrinting] = useState(false);
   const [isExportingJson, setIsExportingJson] = useState(false);
   const [isExportingMarkdown, setIsExportingMarkdown] = useState(false);
@@ -119,6 +126,19 @@ const PdfExport = ({ children }: { children?: React.ReactNode }) => {
       onEnd: () => setIsExportingLongPage(false),
       successMessage: t("toast.success"),
       errorMessage: t("toast.error")
+    });
+  };
+
+  const handleLongPageImageExport = async () => {
+    await exportToLongPageImage({
+      elementId: "resume-preview",
+      title: title || "resume",
+      pagePadding: globalSettings?.pagePadding || 0,
+      fontFamily: globalSettings?.fontFamily,
+      onStart: () => setIsExportingImage(true),
+      onEnd: () => setIsExportingImage(false),
+      successMessage: t("toast.imageSuccess"),
+      errorMessage: t("toast.imageError")
     });
   };
 
@@ -178,20 +198,18 @@ const PdfExport = ({ children }: { children?: React.ReactNode }) => {
   const isLoading =
     isExporting ||
     isExportingLongPage ||
+    isExportingImage ||
     isExportingJson ||
     isExportingMarkdown ||
     isPrinting;
-  const loadingText = isExporting
-    ? t("button.exporting")
-    : isExportingLongPage
+  const loadingText =
+    isExporting || isExportingLongPage || isExportingImage || isPrinting
       ? t("button.exporting")
     : isExportingJson
       ? t("button.exportingJson")
       : isExportingMarkdown
         ? t("button.exportingMarkdown")
-        : isPrinting
-          ? t("button.exporting")
-          : "";
+        : "";
 
   return (
     <Dialog open={isOpen} onOpenChange={(val) => {
@@ -244,6 +262,7 @@ const PdfExport = ({ children }: { children?: React.ReactNode }) => {
               title={t("button.exportPdf")}
               description={t("modal.pdfDesc")}
               isLoading={isExporting}
+              isDisabled={isLoading}
               onClick={handleExport}
               bgGradientClass="from-rose-500/10 dark:from-rose-500/20"
               hoverBorderClass="hover:border-rose-500/40 hover:ring-1 hover:ring-rose-500/20"
@@ -253,15 +272,27 @@ const PdfExport = ({ children }: { children?: React.ReactNode }) => {
               title={t("button.exportLongPagePdf")}
               description={t("modal.longPagePdfDesc")}
               isLoading={isExportingLongPage}
+              isDisabled={isLoading}
               onClick={handleLongPageExport}
               bgGradientClass="from-violet-500/10 dark:from-violet-500/20"
               hoverBorderClass="hover:border-violet-500/40 hover:ring-1 hover:ring-violet-500/20"
+            />
+            <ExportCard
+              icon={ImageGlassIcon}
+              title={t("button.exportLongPageImage")}
+              description={t("modal.longPageImageDesc")}
+              isLoading={isExportingImage}
+              isDisabled={isLoading}
+              onClick={handleLongPageImageExport}
+              bgGradientClass="from-teal-500/10 dark:from-teal-500/20"
+              hoverBorderClass="hover:border-teal-500/40 hover:ring-1 hover:ring-teal-500/20"
             />
             <ExportCard
               icon={PrintGlassIcon}
               title={t("button.print")}
               description={t("modal.printDesc")}
               isLoading={isPrinting}
+              isDisabled={isLoading}
               onClick={handlePrint}
               bgGradientClass="from-sky-500/10 dark:from-sky-500/20"
               hoverBorderClass="hover:border-sky-500/40 hover:ring-1 hover:ring-sky-500/20"
@@ -271,6 +302,7 @@ const PdfExport = ({ children }: { children?: React.ReactNode }) => {
               title={t("button.exportJson")}
               description={t("modal.jsonDesc")}
               isLoading={isExportingJson}
+              isDisabled={isLoading}
               onClick={handleJsonExport}
               bgGradientClass="from-amber-500/10 dark:from-amber-500/20"
               hoverBorderClass="hover:border-amber-500/40 hover:ring-1 hover:ring-amber-500/20"
@@ -280,6 +312,7 @@ const PdfExport = ({ children }: { children?: React.ReactNode }) => {
               title={t("button.exportMarkdown")}
               description={t("modal.markdownDesc")}
               isLoading={isExportingMarkdown}
+              isDisabled={isLoading}
               onClick={handleMarkdownExport}
               bgGradientClass="from-indigo-500/10 dark:from-indigo-500/20"
               hoverBorderClass="hover:border-indigo-500/40 hover:ring-1 hover:ring-indigo-500/20"

--- a/src/config/initialResumeData.ts
+++ b/src/config/initialResumeData.ts
@@ -11,6 +11,7 @@ const initialGlobalSettings: GlobalSettings = {
   useIconMode: true,
   themeColor: "#000000",
   centerSubtitle: true,
+  pageBreakLinesVisible: true,
 };
 
 export const initialResumeState = {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -88,7 +88,7 @@
         },
         {
           "question": "What export formats are supported?",
-          "answer": "We currently support PDF export, ensuring your resume maintains consistent formatting on any device. We plan to support more export formats in the future."
+          "answer": "We currently support PDF export, PNG long image export, browser print, JSON config export, and Markdown export. PDF is best for formal applications and archiving, while PNG long image is useful for mobile previews, portfolio display, or image-upload workflows."
         },
         {
           "question": "How can I sync across devices?",
@@ -259,6 +259,7 @@
       "subtitle": "Select the format you want to export your resume",
       "pdfDesc": "High-precision rendering with 100% format accuracy. Recommended for job applications.",
       "longPagePdfDesc": "Browser-rendered as a single long page. Best for resumes that do not need pagination.",
+      "longPageImageDesc": "Browser-rendered as a single PNG long image. Best for mobile previews, portfolio display, or image-upload workflows.",
       "printDesc": "Save via system print dialog. Use as a fallback or for custom margins.",
       "jsonDesc": "Export your resume data as JSON to backup or transfer between devices.",
       "markdownDesc": "Convert to plain Markdown text for easy sharing with AI models.",
@@ -268,6 +269,7 @@
       "export": "Export",
       "exportPdf": "Export PDF (Server)",
       "exportLongPagePdf": "PDF (Long Page)",
+      "exportLongPageImage": "PNG (Long Image)",
       "exportJson": "Export JSON Config",
       "exportMarkdown": "Export Markdown",
       "exporting": "Exporting...",
@@ -278,6 +280,8 @@
     "toast": {
       "success": "PDF exported successfully",
       "error": "PDF export failed",
+      "imageSuccess": "PNG long image exported successfully",
+      "imageError": "PNG long image export failed",
       "jsonSuccess": "Configuration exported successfully",
       "jsonError": "Configuration export failed",
       "markdownSuccess": "Markdown exported successfully",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -258,6 +258,7 @@
       "title": "Export Resume",
       "subtitle": "Select the format you want to export your resume",
       "pdfDesc": "High-precision rendering with 100% format accuracy. Recommended for job applications.",
+      "longPagePdfDesc": "Browser-rendered as a single long page. Best for resumes that do not need pagination.",
       "printDesc": "Save via system print dialog. Use as a fallback or for custom margins.",
       "jsonDesc": "Export your resume data as JSON to backup or transfer between devices.",
       "markdownDesc": "Convert to plain Markdown text for easy sharing with AI models.",
@@ -266,6 +267,7 @@
     "button": {
       "export": "Export",
       "exportPdf": "Export PDF (Server)",
+      "exportLongPagePdf": "PDF (Long Page)",
       "exportJson": "Export JSON Config",
       "exportMarkdown": "Export Markdown",
       "exporting": "Exporting...",
@@ -322,6 +324,11 @@
       "enabled": "One page mode enabled",
       "disabled": "One page mode disabled",
       "cannotFit": "Too much content. Optimized as much as possible but cannot fit on one page. Try simplifying the content or adjusting margins and font size in the sidebar."
+    },
+    "pageBreakLine": {
+      "tooltip": "Page Break Line",
+      "visible": "Page break line shown",
+      "hidden": "Page break line hidden"
     },
     "backup": {
       "configured": "Backed up",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -260,6 +260,7 @@
       "subtitle": "选择您希望导出简历的格式",
       "pdfDesc": "通过高精度渲染生成，100% 还原格式，简历投递首选。",
       "longPagePdfDesc": "通过浏览器渲染生成一页简历，适合不需要分页的简历。",
+      "longPageImageDesc": "通过浏览器渲染生成单张 PNG 长图，适合移动端预览、作品集展示或要求图片上传的场景。",
       "printDesc": "调用系统打印工具另存为 PDF，当主渲染拥堵或需手动干预边距时的备用方案。",
       "jsonDesc": "保存您的配置档案副本。日后更换设备或清理缓存后，可使用此文件一键无损导入恢复进度。",
       "markdownDesc": "转换为极简的文本标记语言文件，方便快速粘贴给各种 AI 模型或是其他文本编辑器。",
@@ -269,6 +270,7 @@
       "export": "导出",
       "exportPdf": "PDF",
       "exportLongPagePdf": "PDF(长页)",
+      "exportLongPageImage": "PNG(长图)",
       "exportJson": "JSON配置",
       "exportMarkdown": "Markdown",
       "exporting": "导出中...",
@@ -279,6 +281,8 @@
     "toast": {
       "success": "PDF导出成功",
       "error": "PDF导出失败",
+      "imageSuccess": "PNG长图导出成功",
+      "imageError": "PNG长图导出失败",
       "jsonSuccess": "配置导出成功",
       "jsonError": "配置导出失败",
       "markdownSuccess": "Markdown 导出成功",
@@ -812,8 +816,8 @@
         "answer": "推荐使用最新版的 Chrome (谷歌浏览器) 或 Edge 浏览器以获得最佳排版和导出体验。部分不兼容的旧版浏览器可能会导致样式错乱。"
       },
       "export-methods": {
-        "question": "两种导出方式有什么不同？",
-        "answer": "• PDF 导出：使用后端服务进行高精度渲染，100% 还原排版，推荐用于正式发送给 HR。\n\n• 浏览器打印：调用您当前浏览器的自带打印功能（另存为 PDF）。适合在后端导出服务繁忙或您需要通过浏览器微调打印边距时使用。"
+        "question": "有哪些导出方式？",
+        "answer": "• PDF 导出：使用后端服务进行高精度渲染，100% 还原排版，推荐用于正式投递和归档。\n\n• PNG 长图：使用浏览器渲染生成单张长图，适合移动端预览、作品集展示或要求图片上传的场景。\n\n• 浏览器打印：调用您当前浏览器的自带打印功能（另存为 PDF）。适合在后端导出服务繁忙或您需要通过浏览器微调打印边距时使用。\n\n• JSON 配置：导出简历数据副本，方便备份和迁移。\n\n• Markdown：导出为纯文本格式，方便粘贴到其他工具中。"
       },
       "export-failure": {
         "question": "导出失败或样式错乱怎么办？",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -259,6 +259,7 @@
       "title": "导出简历",
       "subtitle": "选择您希望导出简历的格式",
       "pdfDesc": "通过高精度渲染生成，100% 还原格式，简历投递首选。",
+      "longPagePdfDesc": "通过浏览器渲染生成一页简历，适合不需要分页的简历。",
       "printDesc": "调用系统打印工具另存为 PDF，当主渲染拥堵或需手动干预边距时的备用方案。",
       "jsonDesc": "保存您的配置档案副本。日后更换设备或清理缓存后，可使用此文件一键无损导入恢复进度。",
       "markdownDesc": "转换为极简的文本标记语言文件，方便快速粘贴给各种 AI 模型或是其他文本编辑器。",
@@ -267,6 +268,7 @@
     "button": {
       "export": "导出",
       "exportPdf": "PDF",
+      "exportLongPagePdf": "PDF(长页)",
       "exportJson": "JSON配置",
       "exportMarkdown": "Markdown",
       "exporting": "导出中...",
@@ -735,6 +737,11 @@
       "enabled": "已开启一页纸模式",
       "disabled": "已关闭一页纸模式",
       "cannotFit": "内容较多，已尽量压缩但无法完美一页，建议精简内容, 也可在此基础上调节页边距、字体大小等左侧设置栏选项"
+    },
+    "pageBreakLine": {
+      "tooltip": "分页线",
+      "visible": "已显示分页线",
+      "hidden": "已隐藏分页线"
     },
     "backup": {
       "configured": "已备份",

--- a/src/types/resume.ts
+++ b/src/types/resume.ts
@@ -139,6 +139,7 @@ export type GlobalSettings = {
   centerSubtitle?: boolean | undefined;
   flexibleHeaderLayout?: boolean | undefined;
   autoOnePage?: boolean | undefined;
+  pageBreakLinesVisible?: boolean | undefined;
 };
 
 export interface ResumeTheme {

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -1,6 +1,6 @@
 import { toast } from "sonner";
 import { PDF_EXPORT_CONFIG } from "@/config";
-import { normalizeFontFamily } from "@/utils/fonts";
+import { getFontFaceCss, normalizeFontFamily } from "@/utils/fonts";
 import { ResumeData } from "@/types/resume";
 import { generateResumeMarkdown, ResumeMarkdownOptions } from "@/utils/markdown";
 
@@ -106,6 +106,28 @@ export interface ExportToPdfOptions {
   errorMessage?: string;
 }
 
+const A4_WIDTH_MM = 210;
+const PX_PER_MM = 96 / 25.4;
+const LONG_PAGE_HEIGHT_BUFFER_MM = 2;
+const LONG_PAGE_CAPTURE_BUFFER_PX = 8;
+const LONG_PAGE_BOTTOM_SAFE_AREA_PX = 8;
+
+const keepOnlyFirstPage = (pdf: jsPDF) => {
+  const pdfWithPageControl = pdf as jsPDF & {
+    getNumberOfPages?: () => number;
+    deletePage?: (pageNumber: number) => void;
+  };
+
+  const totalPages = pdfWithPageControl.getNumberOfPages?.() ?? 1;
+  if (totalPages <= 1 || !pdfWithPageControl.deletePage) {
+    return;
+  }
+
+  for (let pageNumber = totalPages; pageNumber > 1; pageNumber -= 1) {
+    pdfWithPageControl.deletePage(pageNumber);
+  }
+};
+
 interface ExportResumeFileOptions {
   resume?: ResumeData | null;
   title?: string;
@@ -174,6 +196,172 @@ export const exportResumeAsMarkdown = ({
   }
 };
 
+const hidePageBreakLines = (element: HTMLElement) => {
+  const pageBreakLines = element.querySelectorAll<HTMLElement>(".page-break-line");
+  pageBreakLines.forEach((line) => {
+    line.remove();
+  });
+};
+
+const removeLongPageHeightConstraints = (element: HTMLElement) => {
+  const rootElement = element.firstElementChild as HTMLElement | null;
+  if (rootElement) {
+    rootElement.style.setProperty("height", "auto", "important");
+    rootElement.style.setProperty("min-height", "0", "important");
+  }
+
+  const constrainedElements = element.querySelectorAll<HTMLElement>(".min-h-screen, .min-h-full, .editorial-print-container");
+  constrainedElements.forEach((node) => {
+    node.style.setProperty("height", "auto", "important");
+    node.style.setProperty("min-height", "0", "important");
+  });
+};
+
+const getPreviewScale = (element: HTMLElement) => {
+  const transformValue = element.style.transform || "";
+  const scaleMatch = transformValue.match(/scale\(([\d.]+)\)/);
+  if (!scaleMatch) return 1;
+
+  const scale = Number(scaleMatch[1]);
+  return Number.isFinite(scale) && scale > 0 ? scale : 1;
+};
+
+const waitForImages = async (element: HTMLElement) => {
+  const images = Array.from(element.getElementsByTagName("img"));
+  await Promise.all(
+    images
+      .filter((img) => !img.complete)
+      .map(
+        (img) =>
+          new Promise<void>((resolve) => {
+            img.onload = () => resolve();
+            img.onerror = () => resolve();
+          })
+      )
+  );
+};
+
+export const exportToLongPagePdf = async ({
+  elementId,
+  title,
+  pagePadding,
+  fontFamily,
+  onStart,
+  onEnd,
+  successMessage,
+  errorMessage
+}: ExportToPdfOptions) => {
+  const exportStartTime = performance.now();
+  onStart?.();
+
+  let container: HTMLDivElement | null = null;
+
+  try {
+    const pdfElement = document.querySelector<HTMLElement>(`#${elementId}`);
+    if (!pdfElement) {
+      throw new Error(`PDF element #${elementId} not found`);
+    }
+
+    const selectedFontFamily = normalizeFontFamily(fontFamily);
+    const clonedElement = pdfElement.cloneNode(true) as HTMLElement;
+    const previewScale = getPreviewScale(clonedElement);
+    hidePageBreakLines(clonedElement);
+    removeLongPageHeightConstraints(clonedElement);
+    await optimizeImages(clonedElement);
+
+    clonedElement.style.setProperty("padding", `${pagePadding}px`, "important");
+    clonedElement.style.setProperty("box-sizing", "border-box", "important");
+    clonedElement.style.setProperty("background", "white", "important");
+    clonedElement.style.setProperty("font-family", selectedFontFamily, "important");
+
+    const bottomSpacer = document.createElement("div");
+    bottomSpacer.setAttribute("aria-hidden", "true");
+    bottomSpacer.style.width = "100%";
+    bottomSpacer.style.height = `${Math.ceil(LONG_PAGE_BOTTOM_SAFE_AREA_PX / previewScale)}px`;
+    bottomSpacer.style.pointerEvents = "none";
+    clonedElement.appendChild(bottomSpacer);
+
+    container = document.createElement("div");
+    container.style.position = "fixed";
+    container.style.left = "-10000px";
+    container.style.top = "0";
+    container.style.width = `${A4_WIDTH_MM}mm`;
+    container.style.background = "white";
+    container.style.pointerEvents = "none";
+    container.style.zIndex = "-1";
+
+    const fontStyles = document.createElement("style");
+    fontStyles.textContent = await getFontFaceCss(selectedFontFamily);
+    container.appendChild(fontStyles);
+    container.appendChild(clonedElement);
+    document.body.appendChild(container);
+
+    await waitForImages(clonedElement);
+    if (document.fonts?.ready) {
+      await document.fonts.ready;
+    }
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    });
+
+    const renderedRect = clonedElement.getBoundingClientRect();
+    const contentWidthPx =
+      renderedRect.width || clonedElement.scrollWidth || A4_WIDTH_MM * PX_PER_MM;
+    const contentHeightPx = Math.max(
+      renderedRect.height,
+      clonedElement.scrollHeight * previewScale,
+      1
+    );
+    const pageHeightMm = Math.max(
+      contentHeightPx * (A4_WIDTH_MM / contentWidthPx) + LONG_PAGE_HEIGHT_BUFFER_MM,
+      1
+    );
+    const [{ default: html2canvas }, { jsPDF }] = await Promise.all([
+      import("html2canvas"),
+      import("jspdf")
+    ]);
+
+    const fileName = `${getSafeFileName(title)}.pdf`;
+    const canvas = await html2canvas(clonedElement, {
+      scale: 2,
+      useCORS: true,
+      allowTaint: true,
+      backgroundColor: "#ffffff",
+      scrollX: 0,
+      scrollY: 0,
+      windowWidth: Math.ceil(contentWidthPx),
+      windowHeight: Math.ceil(contentHeightPx + LONG_PAGE_CAPTURE_BUFFER_PX)
+    });
+
+    const imageHeightMm = canvas.height * (A4_WIDTH_MM / canvas.width);
+    const canvasPageHeightMm = Math.max(
+      imageHeightMm + LONG_PAGE_HEIGHT_BUFFER_MM,
+      pageHeightMm
+    );
+    const pdf = new jsPDF({
+      unit: "mm",
+      format: [A4_WIDTH_MM, canvasPageHeightMm],
+      orientation: "portrait",
+      compress: true
+    });
+    const imageData = canvas.toDataURL("image/png");
+    pdf.addImage(imageData, "PNG", 0, 0, A4_WIDTH_MM, imageHeightMm);
+    keepOnlyFirstPage(pdf);
+    pdf.save(fileName);
+
+    if (successMessage) toast.success(successMessage);
+    console.log(`Total long page export took ${performance.now() - exportStartTime}ms`);
+  } catch (error) {
+    console.error("Long page export error:", error);
+    if (errorMessage) toast.error(errorMessage);
+  } finally {
+    if (container?.parentNode) {
+      container.parentNode.removeChild(container);
+    }
+    onEnd?.();
+  }
+};
+
 export const exportToPdf = async ({
   elementId,
   title,
@@ -215,10 +403,7 @@ export const exportToPdf = async ({
     clonedElement.style.setProperty("box-sizing", "border-box");
     clonedElement.style.setProperty("font-family", selectedFontFamily, "important");
 
-    const pageBreakLines = clonedElement.querySelectorAll<HTMLElement>(".page-break-line");
-    pageBreakLines.forEach((line) => {
-      line.style.display = "none";
-    });
+    hidePageBreakLines(clonedElement);
 
     const [capturedStyles] = await Promise.all([
       getOptimizedStyles(),

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -1,4 +1,5 @@
 import { toast } from "sonner";
+import type { jsPDF as JsPDF } from "jspdf";
 import { PDF_EXPORT_CONFIG } from "@/config";
 import { getFontFaceCss, normalizeFontFamily } from "@/utils/fonts";
 import { ResumeData } from "@/types/resume";
@@ -112,8 +113,8 @@ const LONG_PAGE_HEIGHT_BUFFER_MM = 2;
 const LONG_PAGE_CAPTURE_BUFFER_PX = 8;
 const LONG_PAGE_BOTTOM_SAFE_AREA_PX = 8;
 
-const keepOnlyFirstPage = (pdf: jsPDF) => {
-  const pdfWithPageControl = pdf as jsPDF & {
+const keepOnlyFirstPage = (pdf: JsPDF) => {
+  const pdfWithPageControl = pdf as JsPDF & {
     getNumberOfPages?: () => number;
     deletePage?: (pageNumber: number) => void;
   };
@@ -241,19 +242,19 @@ const waitForImages = async (element: HTMLElement) => {
   );
 };
 
-export const exportToLongPagePdf = async ({
-  elementId,
-  title,
-  pagePadding,
-  fontFamily,
-  onStart,
-  onEnd,
-  successMessage,
-  errorMessage
-}: ExportToPdfOptions) => {
-  const exportStartTime = performance.now();
-  onStart?.();
+interface LongPageCapture {
+  container: HTMLDivElement;
+  clonedElement: HTMLElement;
+  contentWidthPx: number;
+  contentHeightPx: number;
+  pageHeightMm: number;
+}
 
+const prepareLongPageCapture = async ({
+  elementId,
+  pagePadding,
+  fontFamily
+}: Pick<ExportToPdfOptions, "elementId" | "pagePadding" | "fontFamily">): Promise<LongPageCapture> => {
   let container: HTMLDivElement | null = null;
 
   try {
@@ -316,27 +317,91 @@ export const exportToLongPagePdf = async ({
       contentHeightPx * (A4_WIDTH_MM / contentWidthPx) + LONG_PAGE_HEIGHT_BUFFER_MM,
       1
     );
-    const [{ default: html2canvas }, { jsPDF }] = await Promise.all([
-      import("html2canvas"),
-      import("jspdf")
-    ]);
+
+    return {
+      container,
+      clonedElement,
+      contentWidthPx,
+      contentHeightPx,
+      pageHeightMm
+    };
+  } catch (error) {
+    if (container?.parentNode) {
+      container.parentNode.removeChild(container);
+    }
+    throw error;
+  }
+};
+
+const renderLongPageCanvas = async ({
+  clonedElement,
+  contentWidthPx,
+  contentHeightPx
+}: Pick<LongPageCapture, "clonedElement" | "contentWidthPx" | "contentHeightPx">) => {
+  const { default: html2canvas } = await import("html2canvas");
+
+  return html2canvas(clonedElement, {
+    scale: 2,
+    useCORS: true,
+    allowTaint: true,
+    backgroundColor: "#ffffff",
+    scrollX: 0,
+    scrollY: 0,
+    windowWidth: Math.ceil(contentWidthPx),
+    windowHeight: Math.ceil(contentHeightPx + LONG_PAGE_CAPTURE_BUFFER_PX)
+  });
+};
+
+const getCanvasPngBlob = (canvas: HTMLCanvasElement) =>
+  new Promise<Blob>((resolve, reject) => {
+    try {
+      canvas.toBlob((blob) => {
+        if (!blob) {
+          reject(new Error("PNG conversion failed"));
+          return;
+        }
+
+        resolve(blob);
+      }, "image/png");
+    } catch (error) {
+      reject(error);
+    }
+  });
+
+export const exportToLongPagePdf = async ({
+  elementId,
+  title,
+  pagePadding,
+  fontFamily,
+  onStart,
+  onEnd,
+  successMessage,
+  errorMessage
+}: ExportToPdfOptions) => {
+  const exportStartTime = performance.now();
+  onStart?.();
+
+  let capture: LongPageCapture | null = null;
+  let canvas: HTMLCanvasElement | null = null;
+
+  try {
+    capture = await prepareLongPageCapture({
+      elementId,
+      pagePadding,
+      fontFamily
+    });
 
     const fileName = `${getSafeFileName(title)}.pdf`;
-    const canvas = await html2canvas(clonedElement, {
-      scale: 2,
-      useCORS: true,
-      allowTaint: true,
-      backgroundColor: "#ffffff",
-      scrollX: 0,
-      scrollY: 0,
-      windowWidth: Math.ceil(contentWidthPx),
-      windowHeight: Math.ceil(contentHeightPx + LONG_PAGE_CAPTURE_BUFFER_PX)
-    });
+    const [{ jsPDF }, renderedCanvas] = await Promise.all([
+      import("jspdf"),
+      renderLongPageCanvas(capture)
+    ]);
+    canvas = renderedCanvas;
 
     const imageHeightMm = canvas.height * (A4_WIDTH_MM / canvas.width);
     const canvasPageHeightMm = Math.max(
       imageHeightMm + LONG_PAGE_HEIGHT_BUFFER_MM,
-      pageHeightMm
+      capture.pageHeightMm
     );
     const pdf = new jsPDF({
       unit: "mm",
@@ -355,8 +420,57 @@ export const exportToLongPagePdf = async ({
     console.error("Long page export error:", error);
     if (errorMessage) toast.error(errorMessage);
   } finally {
-    if (container?.parentNode) {
-      container.parentNode.removeChild(container);
+    if (canvas) {
+      canvas.width = 0;
+      canvas.height = 0;
+    }
+    if (capture?.container.parentNode) {
+      capture.container.parentNode.removeChild(capture.container);
+    }
+    onEnd?.();
+  }
+};
+
+export const exportToLongPageImage = async ({
+  elementId,
+  title,
+  pagePadding,
+  fontFamily,
+  onStart,
+  onEnd,
+  successMessage,
+  errorMessage
+}: ExportToPdfOptions) => {
+  const exportStartTime = performance.now();
+  onStart?.();
+
+  let capture: LongPageCapture | null = null;
+  let canvas: HTMLCanvasElement | null = null;
+
+  try {
+    capture = await prepareLongPageCapture({
+      elementId,
+      pagePadding,
+      fontFamily
+    });
+
+    canvas = await renderLongPageCanvas(capture);
+    const blob = await getCanvasPngBlob(canvas);
+    const fileName = `${getSafeFileName(title)}.png`;
+    downloadBlob(blob, fileName);
+
+    if (successMessage) toast.success(successMessage);
+    console.log(`Total long page image export took ${performance.now() - exportStartTime}ms`);
+  } catch (error) {
+    console.error("Long page image export error:", error);
+    if (errorMessage) toast.error(errorMessage);
+  } finally {
+    if (canvas) {
+      canvas.width = 0;
+      canvas.height = 0;
+    }
+    if (capture?.container.parentNode) {
+      capture.container.parentNode.removeChild(capture.container);
     }
     onEnd?.();
   }


### PR DESCRIPTION
作者您好，在面试求职过程中我发现一些问题
   - 简历内容刚好超过标准A4纸一点，导致第二页大量空白
   - 求职过程中可能存在只需要单页pdf或者图片的情况
综合以上多种原因，我提交了本次pr希望能解决类似问题

  **Summary**                                                                                                                                                  
         
  - 新增长页 PDF 导出：将简历渲染为单页长 PDF，适合不需要分页的场景                                                                                        
  - 新增长图 PNG 导出：将简历渲染为单张长图，适合移动端预览、作品集展示或图片上传场景                                                                      
  - 新增分页线显示/隐藏切换按钮，长页导出时自动隐藏分页线                                                                                                  
  - 导出弹窗中各按钮增加互斥禁用状态，避免并发导出冲突                                                                                                     
  - 更新中英文 i18n 翻译，补充所有导出方式的 FAQ 说明                                                                                                      
                                                                                                                                                           
  **Principle**                                                                                                                                                 
                                                                                                                                                           
  核心思路是将预览区 DOM 克隆到一个离屏容器中，解除高度约束后渲染为完整长图，再按需输出为 PDF 或 PNG：                                                     
                  
  1. 离屏克隆：将 #resume-preview 元素 cloneNode(true)，插入一个 position: fixed; left: -10000px 的隐藏容器，避免影响页面可见区域                          
  2. 解除分页约束：移除克隆元素中的 .page-break-line，并将 min-h-screen、min-h-full 等固定高度样式设为 height: auto，使内容自然撑开为单页
  3. html2canvas 截图：等待图片和字体加载完成后，使用 html2canvas 以 2x 缩放渲染完整 canvas                                                                
  4. 输出文件：                                                                                                                                            
    - 长页 PDF：基于 canvas 高度动态计算页面尺寸，创建自定义高度的 jsPDF 单页文档，将 canvas 作为图片写入                                                  
    - 长图 PNG：直接通过 canvas.toBlob 导出 PNG 文件                                                                                                       
                                                                                                                                                           
  **Test plan**                                                                                                                                                
                                                                                                                                                           
  - 在导出弹窗中分别点击"PDF（长页）"和"PNG（长图）"，验证文件能正常下载且内容完整                                                                         
  - 验证导出过程中按钮显示 loading 且其他导出按钮被禁用
  - 点击预览区 Dock 栏的分页线切换按钮，确认分页线可正常显示/隐藏                                                                                          
  - 切换中英文语言，确认新增的导出描述和 toast 提示文案正确显示                                                                                            
  - 在 FAQ 页面确认导出方式说明已更新 