### PR TITLE
fix: date range input bug in newly created work experience

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -435,7 +435,7 @@
       "defaultProject": {
         "company": "Tech Company Ltd.",
         "position": "Senior Frontend Engineer",
-        "date": "2020-Present",
+        "date": "2020 - Present",
         "details": "Responsible for core product development..."
       },
       "placeholders": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -392,7 +392,7 @@
       "defaultProject": {
         "company": "某科技有限公司",
         "position": "高级前端工程师",
-        "date": "2020-至今",
+        "date": "2020 - 至今",
         "details": "负责公司核心产品..."
       },
       "placeholders": {


### PR DESCRIPTION
问题描述:
在"工作经验"模块下通过点击"添加工作经历"创建新的经历，默认给的时间范围格式未被解析正确，该默认值源于本地化翻译json文档中

问题截图:
<img width="711" height="96" alt="image" src="https://github.com/user-attachments/assets/6822a06e-78af-486a-b2e5-5df094391a8d" />
<img width="439" height="632" alt="image" src="https://github.com/user-attachments/assets/8c9180d8-70bc-4e9d-8e45-254b62675fef" />
