### PR TITLE
修复：更新已弃用的 DeepSeek 默认模型标识

### DIFF
--- a/src/config/ai.ts
+++ b/src/config/ai.ts
@@ -33,7 +33,7 @@ export const AI_MODEL_CONFIGS: Record<AIModelType, AIModelConfig> = {
   deepseek: {
     url: () => "https://api.deepseek.com/v1/chat/completions",
     requiresModelId: false,
-    defaultModel: "deepseek-chat",
+    defaultModel: "deepseek-v4-flash",
     headers: (apiKey: string) => ({
       "Content-Type": "application/json",
       Authorization: `Bearer ${apiKey}`,

--- a/src/routes/api/grammar.ts
+++ b/src/routes/api/grammar.ts
@@ -98,6 +98,7 @@ export const Route = createFileRoute("/api/grammar")({
             headers: modelConfig.headers(apiKey),
             body: JSON.stringify({
               model: modelConfig.requiresModelId ? model : modelConfig.defaultModel,
+              ...(modelType === "deepseek" ? { thinking: { type: "disabled" } } : {}),
               response_format: {
                 type: "json_object"
               },

--- a/src/routes/api/polish.ts
+++ b/src/routes/api/polish.ts
@@ -105,6 +105,7 @@ export const Route = createFileRoute("/api/polish")({
             headers: modelConfig.headers(apiKey),
             body: JSON.stringify({
               model: modelConfig.requiresModelId ? model : modelConfig.defaultModel,
+              ...(modelType === "deepseek" ? { thinking: { type: "disabled" } } : {}),
               messages: [
                 {
                   role: "system",


### PR DESCRIPTION
## 概要

- 将内置 DeepSeek 默认模型从已弃用的 `deepseek-chat` 更新为 `deepseek-v4-flash`。
- 对 DeepSeek 的简历润色与语法检查请求显式传递 `thinking: { type: "disabled" }`，保持旧默认模型的非思考行为。

## 根因

`deepseek-chat` 已退役。迁移到 `deepseek-v4-flash` 后，如果不指定 `thinking`，DeepSeek 会默认启用思考模式；旧模型别名对应的是非思考模式。两个 API 路由都从相同的 provider 配置获取默认模型，因此需要同时控制其上游请求载荷。

## 验证

- `pnpm build` 通过。
- 使用已配置的真实 DeepSeek 密钥：
  - `POST /api/grammar`：HTTP 200，返回有效且非空的 JSON 内容。
  - `POST /api/polish`：HTTP 200，流式输出非空。
- 同一密钥的 QLing 对照请求确认：显式禁用思考后，`deepseek-v4-flash` 返回 HTTP 200 和预期最终内容。

关联 Issue：Fixes #369
