### PR TITLE
feat(i18n): add Filipino/Tagalog (tl) locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <a href="https://trendshift.io/repositories/13077" target="_blank"><img src="https://trendshift.io/api/badge/repositories/13077" alt="Magic Resume | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
-[简体中文](./README.zh-CN.md) | English
+[简体中文](./README.zh-CN.md) | English | [Filipino](./README.tl.md)
 
 </div>
 
@@ -30,6 +30,19 @@ Magic Resume is a modern online resume editor that makes creating professional r
 - 🔄 Real-time preview
 - 💾 Auto-save
 - 🔒 Local storage
+- 🌐 Multi-language UI (中文, English, Filipino)
+
+## 🌐 Languages
+
+Magic Resume supports three locales. Switch languages from the header, or open a locale directly:
+
+| Locale | Language | URL |
+| ------ | -------- | --- |
+| `zh` | 中文 (default) | `/zh` |
+| `en` | English | `/en` |
+| `tl` | Filipino / Tagalog | `/tl` |
+
+Translations live in [`src/i18n/locales/`](src/i18n/locales/). To add or update strings, edit the matching JSON file (for example `tl.json` for Filipino).
 
 ## 🛠️ Tech Stack
 
@@ -63,7 +76,7 @@ pnpm install
 pnpm dev
 ```
 
-4. Open browser and visit `http://localhost:3000`
+4. Open browser and visit `http://localhost:3000` (redirects to `/zh` by default, or try `/en` and `/tl`)
 
 ## 📦 Build and Deploy
 
@@ -112,7 +125,7 @@ Please see the [LICENSE](LICENSE) file for detailed terms.
 ## 🗺️ Roadmap
 
 - [x] AI-assisted writing
-- [x] Multi-language support
+- [x] Multi-language support (中文, English, Filipino)
 - [ ] Support for more resume templates
 - [x] Support for more export formats
 - [x] Import PDF, Markdown, etc.

--- a/README.tl.md
+++ b/README.tl.md
@@ -1,0 +1,170 @@
+<div align="center">
+
+# ✨ Magic Resume ✨
+
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+![TanStack Start](https://img.shields.io/badge/TanStack_Start-latest-black)
+![Framer Motion](https://img.shields.io/badge/Framer_Motion-10.0-purple)
+
+<a href="https://trendshift.io/repositories/13077" target="_blank"><img src="https://trendshift.io/api/badge/repositories/13077" alt="Magic Resume | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+
+[简体中文](./README.zh-CN.md) | [English](./README.md) | Filipino
+
+</div>
+
+Ang Magic Resume ay isang modernong online resume editor na ginagawang simple at masaya ang paglikha ng propesyonal na resume. Binuo gamit ang TanStack Start at Framer Motion, may suporta sa real-time preview at custom themes.
+
+## 📸 Mga Screenshot
+
+<img width="1920" height="1440" alt="336_1x_shots_so" src="https://github.com/user-attachments/assets/18969a17-06f8-4a4b-94eb-284ba8442620" />
+
+
+## ✨ Mga Feature
+
+- 🚀 Binuo gamit ang TanStack Start
+- 💫 Makinis na animation (Framer Motion)
+- 🎨 Suporta sa custom theme
+- 📱 Responsive design
+- 🌙 Dark mode
+- 📤 I-export sa PDF
+- 🔄 Real-time preview
+- 💾 Auto-save
+- 🔒 Lokal na imbakan
+- 🌐 Multi-language UI (中文, English, Filipino)
+
+## 🌐 Mga Wika
+
+Sinusuportahan ng Magic Resume ang tatlong locale. Magpalit ng wika sa header, o buksan nang direkta ang locale:
+
+| Locale | Wika | URL |
+| ------ | ---- | --- |
+| `zh` | 中文 (default) | `/zh` |
+| `en` | English | `/en` |
+| `tl` | Filipino / Tagalog | `/tl` |
+
+Nasa [`src/i18n/locales/`](src/i18n/locales/) ang mga translation. Para magdagdag o mag-update ng string, i-edit ang katumbas na JSON file (halimbawa `tl.json` para sa Filipino).
+
+## 🛠️ Tech Stack
+
+- TanStack Start
+- TypeScript
+- Motion
+- Tiptap
+- Tailwind CSS
+- Zustand
+- Shadcn/ui
+- Lucide Icons
+
+## 🚀 Mabilis na Pagsisimula
+
+1. I-clone ang proyekto
+
+```bash
+git clone git@github.com:JOYCEQL/magic-resume.git
+cd magic-resume
+```
+
+2. I-install ang mga dependency
+
+```bash
+pnpm install
+```
+
+3. Simulan ang development server
+
+```bash
+pnpm dev
+```
+
+4. Buksan ang browser at bisitahin ang `http://localhost:3000` (awtomatikong magre-redirect sa `/zh` bilang default, o subukan ang `/en` at `/tl`)
+
+## 📦 Build at Deploy
+
+```bash
+pnpm build
+```
+
+
+## 🐳 Docker Deployment
+
+### Docker Compose
+
+1. Siguraduhing naka-install ang Docker at Docker Compose
+
+2. Patakbuhin ang sumusunod na command sa root directory ng proyekto:
+
+```bash
+docker compose up -d
+```
+
+Ito ay:
+
+- Awtomatikong bubuo ng application image
+- Magsisimula ng container sa background
+
+
+## 📝 Lisensya at Komersyal na Paggamit
+
+Ang source code ng proyektong ito ay open-source sa ilalim ng **Apache 2.0** license, ngunit may **mahigpit na restriksyon sa komersyal na paggamit**:
+
+- **Libre para sa Personal na Paggamit**: Libre gamitin para sa personal at hindi komersyal na layunin (hal., personal na pag-aaral, paggawa ng sariling resume).
+- **Kailangan ng Komersyal na Lisensya**: Mahigpit na ipinagbabawal ang hindi awtorisadong komersyal na paggamit. Anumang organisasyon o indibidwal na mag-aalok nito bilang serbisyo (SaaS/PaaS, atbp.) sa publiko para kumita, gagamitin ito para sa enterprise commercial operations, o magsasagawa ng secondary commercial development, **dapat kumuha ng komersyal na lisensya, kahit binago man ang source code**.
+
+Pakitingnan ang [LICENSE](LICENSE) file para sa detalyadong mga tuntunin.
+
+## 🗺️ Roadmap
+
+- [x] AI-assisted writing
+- [x] Multi-language support (中文, English, Filipino)
+- [ ] Suporta sa mas maraming resume template
+- [ ] Suporta sa mas maraming export format
+- [ ] Mag-import ng PDF, Markdown, atbp.
+- [x] Custom model
+- [x] Auto one page
+- [ ] Online resume hosting
+
+## 📈 Star History
+
+<a href="https://star-history.com/#JOYCEQL/magic-resume&Date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=JOYCEQL/magic-resume&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=JOYCEQL/magic-resume&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=JOYCEQL/magic-resume&type=Date" />
+ </picture>
+</a>
+
+## 📞 Makipag-ugnayan
+
+Maaari mong sundan ang pinakabagong update sa pamamagitan ng:
+
+- Author: Siyue
+- X: @GuangzhouY81070
+- Discord: Sumali sa aming community https://discord.gg/9mWgZrW3VN
+- Email: 18806723365@163.com
+
+
+- Project Homepage: https://github.com/JOYCEQL/magic-resume
+
+## 🌟 Suporta
+
+Kung nakatulong sa iyo ang proyektong ito, magbigay ng star ⭐️
+
+## ❤️ Mga Sponsor
+
+<div align="center">
+  <h3>Sponsors</h3>
+  <p>Kung nag-sponsor ka sa proyektong ito ngunit wala ka rito, makipag-ugnayan sa akin.</p>
+  <p>
+    <a href="https://github.com/yj147">
+      <img src="https://github.com/yj147.png?size=40" width="40" height="40" alt="@yj147" />
+    </a>
+    <a href="https://github.com/someone1128">
+      <img src="https://github.com/someone1128.png?size=40" width="40" height="40" alt="@someone1128" />
+    </a>
+    <!-- Magdagdag ng mas maraming sponsor dito:
+    <a href="https://github.com/<username>">
+      <img src="https://github.com/<username>.png?size=40" width="40" height="40" alt="@<username>" />
+    </a>
+    -->
+  </p>
+</div>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 <a href="https://trendshift.io/repositories/13077" target="_blank"><img src="https://trendshift.io/api/badge/repositories/13077" alt="Magic Resume | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
 
-简体中文 | [English](./README.md)
+简体中文 | [English](./README.md) | [Filipino](./README.tl.md)
 
 </div>
 
@@ -30,6 +30,19 @@ Magic Resume 是一个现代化的在线简历编辑器，让创建专业简历�
 - 🔄 实时预览
 - 💾 自动保存
 - 🔒 硬盘级存储
+- 🌐 多语言界面（中文、English、Filipino）
+
+## 🌐 语言支持
+
+Magic Resume 支持三种语言，可在页面顶部切换，或直接访问对应路径：
+
+| 语言代码 | 语言 | 路径 |
+| -------- | ---- | ---- |
+| `zh` | 中文（默认） | `/zh` |
+| `en` | English | `/en` |
+| `tl` | Filipino / Tagalog | `/tl` |
+
+翻译文件位于 [`src/i18n/locales/`](src/i18n/locales/)，如需新增或修改文案，请编辑对应的 JSON 文件（例如 Filipino 对应 `tl.json`）。
 
 ## 🛠️ 技术栈
 
@@ -63,7 +76,7 @@ pnpm install
 pnpm dev
 ```
 
-4. 打开浏览器访问 `http://localhost:3000`
+4. 打开浏览器访问 `http://localhost:3000`（默认跳转到 `/zh`，也可访问 `/en` 和 `/tl`）
 
 ## 📦 构建打包
 
@@ -112,7 +125,7 @@ docker compose up -d
 ## 🗺️ 路线图
 
 - [x] AI 辅助编写
-- [x] 多语言支持
+- [x] 多语言支持（中文、English、Filipino）
 - [ ] 支持更多简历模板
 - [x] 更多格式导出
 - [x] 自定义模型

--- a/src/app/(public)/[locale]/layout.tsx
+++ b/src/app/(public)/[locale]/layout.tsx
@@ -36,7 +36,7 @@ export async function generateMetadata({
       title: t("title"),
       description: t("description"),
       locale: locale,
-      alternateLocale: locale === "en" ? ["zh"] : ["en"]
+      alternateLocale: locales.filter((entry) => entry !== locale),
     }
   };
 }

--- a/src/app/app/dashboard/templates/page.tsx
+++ b/src/app/app/dashboard/templates/page.tsx
@@ -10,7 +10,8 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import ResumeTemplateComponent from "@/components/templates";
-import { initialResumeState, initialResumeStateEn } from "@/config/initialResumeData";
+import { initialResumeByLocale } from "@/i18n/localeContent";
+import type { Locale } from "@/i18n/config";
 import type { ResumeTemplate } from "@/types/template";
 import { normalizeFontFamily } from "@/utils/fonts";
 
@@ -32,8 +33,7 @@ const getTemplateKey = (templateId: string) =>
   templateId === "left-right" ? "leftRight" : templateId;
 
 type TemplatePreviewBaseData =
-  | typeof initialResumeState
-  | typeof initialResumeStateEn;
+  (typeof initialResumeByLocale)[Locale];
 
 const buildTemplatePreviewData = (
   baseData: TemplatePreviewBaseData,
@@ -235,7 +235,7 @@ const TemplatesPage = () => {
     }
   };
 
-  const baseData = locale === "en" ? initialResumeStateEn : initialResumeState;
+  const baseData = initialResumeByLocale[locale as Locale] ?? initialResumeByLocale.zh;
   const activePreviewTemplate =
     DEFAULT_TEMPLATES.find((template) => template.id === previewTemplate) ??
     null;

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,13 +1,12 @@
 import { MetadataRoute } from "next";
+import { locales } from "@/i18n/config";
 
 export const runtime = "edge";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = "https://magicv.art/";
 
-  const routes = ["zh", "en"];
-
-  const sitemap: MetadataRoute.Sitemap = routes.map((route) => ({
+  const sitemap: MetadataRoute.Sitemap = locales.map((route) => ({
     url: `${baseUrl}${route}`,
     lastModified: new Date(),
     changeFrequency: "daily",

--- a/src/config/initialResumeData.ts
+++ b/src/config/initialResumeData.ts
@@ -379,3 +379,133 @@ export const blankResumeStateEn = {
   certificates: [],
   menuSections: [initialResumeStateEn.menuSections[0]],
 };
+
+export const initialResumeStateTl = {
+  ...initialResumeStateEn,
+  title: "Bagong Resume",
+  basic: {
+    ...initialResumeStateEn.basic,
+    name: "Juan",
+    title: "Senior Frontend Engineer",
+    employementStatus: "Available",
+    email: "juan.delacruz@example.com",
+    phone: "0917-123-4567",
+    location: "Makati, Metro Manila",
+  },
+  education: [
+    {
+      ...initialResumeStateEn.education[0],
+      school: "University of the Philippines",
+      major: "Computer Science",
+      description: `<ul>
+        <li>Mga pangunahing kurso: Data Structures, Algorithms, Operating Systems, Computer Networks, Web Development</li>
+        <li>Nasa top 5% ng klase, tumanggap ng Dean's List honors sa tatlong sunod-sunod na taon</li>
+        <li>Nagsilbing Technical Director ng Computer Science Association, nag-organisa ng maraming tech workshop</li>
+        <li>Nag-ambag sa open-source projects, nakuha ang GitHub Campus Expert certification</li>
+      </ul>`,
+    },
+  ],
+  skillContent: `<div class="skill-content">
+  <ul>
+    <li>Frontend Frameworks: React, Vue.js, Next.js, Nuxt.js at iba pang SSR frameworks</li>
+    <li>Mga Wika: TypeScript, JavaScript(ES6+), HTML5, CSS3</li>
+    <li>UI/Styling: TailwindCSS, Sass/Less, CSS Modules, Styled-components</li>
+    <li>State Management: Redux, Vuex, Zustand, Jotai, React Query</li>
+    <li>Build Tools: Webpack, Vite, Rollup, Babel, ESLint</li>
+    <li>Testing: Jest, React Testing Library, Cypress</li>
+    <li>Performance: Browser rendering principles, performance metrics monitoring, code splitting, lazy loading</li>
+    <li>Version Control: Git, SVN</li>
+    <li>Technical Leadership: May karanasan sa team management, nanguna sa technology selection at architecture design para sa malalaking proyekto</li>
+  </ul>
+</div>`,
+  experience: [
+    {
+      ...initialResumeStateEn.experience[0],
+      company: "Grab Philippines",
+      position: "Senior Frontend Engineer",
+      details: `<ul>
+      <li>Responsable sa development at maintenance ng Creator Platform, nanguna sa technical solution design para sa core features</li>
+      <li>Na-optimize ang build configuration, binawasan ang build time mula 8 minuto patungong 2 minuto</li>
+      <li>Nag-disenyo at nag-implement ng component library, tumaas ang code reuse ng 70%</li>
+      <li>Nanguna sa performance optimization project, binawasan ang first-screen loading time ng 50%</li>
+      <li>Nag-mentor sa junior engineers, nag-organisa ng technical sharing sessions</li>
+    </ul>`,
+    },
+  ],
+  projects: initialResumeStateEn.projects.map((project) => ({
+    ...project,
+    name:
+      project.id === "p1"
+        ? "Creator Platform"
+        : project.id === "p2"
+          ? "Mini Program Developer Tools"
+          : "Frontend Monitoring Platform",
+    role:
+      project.id === "p1"
+        ? "Frontend Lead"
+        : project.id === "p2"
+          ? "Core Developer"
+          : "Technical Lead",
+  })),
+  menuSections: [
+    {
+      id: "basic",
+      title: "Profile",
+      icon: "👤",
+      enabled: true,
+      order: 0,
+    },
+    {
+      id: "skills",
+      title: "Mga Kasanayan",
+      icon: "⚡",
+      enabled: true,
+      order: 1,
+    },
+    {
+      id: "experience",
+      title: "Karanasan",
+      icon: "💼",
+      enabled: true,
+      order: 2,
+    },
+    {
+      id: "projects",
+      title: "Mga Proyekto",
+      icon: "🚀",
+      enabled: true,
+      order: 3,
+    },
+    {
+      id: "education",
+      title: "Edukasyon",
+      icon: "🎓",
+      enabled: true,
+      order: 4,
+    },
+  ],
+};
+
+export const blankResumeStateTl = {
+  ...initialResumeStateTl,
+  title: "Bagong Resume",
+  basic: {
+    ...initialResumeStateTl.basic,
+    name: "",
+    title: "",
+    email: "",
+    phone: "",
+    location: "",
+    birthDate: "",
+    employementStatus: "",
+    photo: "",
+    customFields: [],
+  },
+  education: [],
+  skillContent: "",
+  selfEvaluationContent: "",
+  experience: [],
+  projects: [],
+  certificates: [],
+  menuSections: [initialResumeStateTl.menuSections[0]],
+};

--- a/src/i18n/compat/server.ts
+++ b/src/i18n/compat/server.ts
@@ -1,14 +1,13 @@
 import { defaultLocale, Locale } from "@/i18n/config";
-import zhMessages from "@/i18n/locales/zh.json";
-import enMessages from "@/i18n/locales/en.json";
+import { getMessagesForLocale, messagesByLocale } from "@/i18n/messages";
 import { createTranslator } from "./utils";
 
 type Messages = Record<string, unknown>;
 
-const MESSAGES: Record<Locale, Messages> = {
-  zh: zhMessages as Messages,
-  en: enMessages as Messages
-};
+const MESSAGES: Record<Locale, Messages> = messagesByLocale as Record<
+  Locale,
+  Messages
+>;
 
 let requestLocale: Locale = defaultLocale;
 

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -1,4 +1,4 @@
-export const locales = ["zh", "en"] as const;
+export const locales = ["zh", "en", "tl"] as const;
 export type Locale = (typeof locales)[number];
 
 export const defaultLocale: Locale = "zh";
@@ -6,4 +6,5 @@ export const defaultLocale: Locale = "zh";
 export const localeNames: Record<Locale, string> = {
   zh: "中文",
   en: "English",
+  tl: "Filipino",
 };

--- a/src/i18n/localeContent.ts
+++ b/src/i18n/localeContent.ts
@@ -1,0 +1,40 @@
+import type { Locale } from "@/i18n/config";
+import {
+  blankResumeState,
+  blankResumeStateEn,
+  blankResumeStateTl,
+  initialResumeState,
+  initialResumeStateEn,
+  initialResumeStateTl,
+} from "@/config/initialResumeData";
+
+export const initialResumeByLocale = {
+  zh: initialResumeState,
+  en: initialResumeStateEn,
+  tl: initialResumeStateTl,
+} as const;
+
+export const blankResumeByLocale = {
+  zh: blankResumeState,
+  en: blankResumeStateEn,
+  tl: blankResumeStateTl,
+} as const;
+
+export const defaultResumeTitleByLocale: Record<Locale, string> = {
+  zh: "新建简历",
+  en: "New Resume",
+  tl: "Bagong Resume",
+};
+
+export const copyLabelByLocale: Record<Locale, string> = {
+  zh: "复制",
+  en: "Copy",
+  tl: "Kopyahin",
+};
+
+export const resolveLocaleFromCookie = (cookieValue?: string): Locale => {
+  if (cookieValue === "en" || cookieValue === "tl" || cookieValue === "zh") {
+    return cookieValue;
+  }
+  return "zh";
+};

--- a/src/i18n/locales/tl.json
+++ b/src/i18n/locales/tl.json
@@ -1,0 +1,822 @@
+{
+  "common": {
+    "title": "Magic Resume",
+    "subtitle": "AI na Resume Editor",
+    "description": "Ang Magic Resume ay isang open source na resume editor, libre at privacy-first. Walang kailangang rehistro, lahat ng data ay naka-imbak nang lokal, may suporta sa backup at export, para laging available ang iyong resume data.",
+    "dashboard": "Dashboard",
+    "edit": "I-edit",
+    "delete": "Tanggalin",
+    "newResume": "Bagong Resume",
+    "copy": "Kopyahin",
+    "cancel": "Kanselahin",
+    "confirm": "Kumpirmahin",
+    "deleteSuccess": "Matagumpay na natanggal",
+    "deleteModuleConfirm": "Sigurado ka bang gusto mong tanggalin ang module na ito? Hindi na ito maaaring ibalik.",
+    "configured": "Naka-configure",
+    "notConfigured": "Hindi naka-configure"
+  },
+  "home": {
+    "header": {
+      "title": "Magic Resume",
+      "startButton": "Magsimula",
+      "features": "Mga Feature",
+      "pricing": "Presyo",
+      "about": "Tungkol",
+      "login": "Mag-login",
+      "register": "Magrehistro",
+      "dashboard": "Dashboard"
+    },
+    "hero": {
+      "badge": "Matalinong Paglikha ng Resume",
+      "title": "Gawing Simple at Matalino ang Paglikha ng Resume",
+      "subtitle": "Ginagamit ng Magic Resume ang AI technology para mabilis kang makagawa ng propesyonal na resume. Walang rehistro, libre, at ligtas ang iyong data.",
+      "cta": "Magsimula",
+      "secondary": "Tingnan ang mga Template"
+    },
+    "features": {
+      "title": "Bakit Piliin ang Magic Resume?",
+      "subtitle": "Nagbibigay kami ng all-in-one na solusyon sa resume para mas maging maayos ang iyong paghahanap ng trabaho",
+      "ai": {
+        "badge": "AI Smart Check",
+        "title": "Matalinong Deteksyon, Propesyonal na Payo",
+        "description": "May built-in na smart grammar check, awtomatikong nakikilala ang hindi angkop na pahayag, nagbibigay ng propesyonal na mungkahi sa pagbabago, para mas maging kapansin-pansin ang iyong resume.",
+        "item1": "Matalinong pagpapahusay",
+        "item1_description": "Awtomatikong ino-optimize ng AI ang pagpapahayag ng content, para mas maging propesyonal ang iyong resume",
+        "item2": "Grammar check",
+        "item2_description": "Awtomatikong nakikita at itinatama ang mga error sa grammar at spelling"
+      },
+      "storage": {
+        "badge": "Lokal na Imbakan",
+        "title": "Seguridad ng Data, Privacy Muna",
+        "description": "Lahat ng resume data ay ganap na naka-imbak nang lokal, hindi mo kailangang mag-alala sa privacy leak. May suporta sa data export backup, para laging available ang iyong resume data.",
+        "item1": "Lokal na file storage",
+        "item1_description": "Ligtas na naka-imbak ang resume data sa hard drive ng iyong computer",
+        "item2": "Maraming export format",
+        "item2_description": "May suporta sa PDF at JSON format export",
+        "item3": "May suporta sa data export backup"
+      },
+      "preview": {
+        "badge": "Real-time Preview",
+        "title": "Ano ang Nakikita Mo, Iyon ang Makukuha Mo",
+        "item1": "Real-time preview ng editing effects",
+        "item2": "Maraming export format na suportado"
+      }
+    },
+    "news": {
+      "label": "Balita",
+      "content": "Live na ang Bagong AI Resume Enhancement Feature"
+    },
+    "footer": {
+      "copyright": " 2025 Magic Resume. Lahat ng karapatan ay nakalaan."
+    },
+    "changelog": "Changelog",
+    "cta": {
+      "title": "Simulan ang Iyong Bagong Kabanata sa Karera",
+      "description": "Simulan nang gamitin ang Magic Resume para gumawa ng kapansin-pansing resume",
+      "button": "Simulang Gamitin nang Libre"
+    },
+    "faq": {
+      "title": "Mga Madalas Itanong",
+      "items": [
+        {
+          "question": "Libre bang gamitin ang Magic Resume?",
+          "answer": "Kasalukuyang libre ang Magic Resume, na tumutugon sa pangunahing pangangailangan sa paglikha ng resume. Hindi magbabago ang mga feature ng open-source na bersyon"
+        },
+        {
+          "question": "Ligtas ba ang aking resume data?",
+          "answer": "Oo, napakaligtas. Gumagamit ang Magic Resume ng lokal na imbakan, ibig sabihin lahat ng iyong data ay naka-imbak sa sarili mong device na walang cloud storage, na tinitiyak ang kumpletong proteksyon ng privacy."
+        },
+        {
+          "question": "Anong mga export format ang suportado?",
+          "answer": "Kasalukuyan naming sinusuportahan ang PDF export, na tinitiyak na pare-pareho ang format ng iyong resume sa anumang device. Plano naming suportahan ang mas maraming export format sa hinaharap."
+        },
+        {
+          "question": "Paano ako makakapag-sync sa iba't ibang device?",
+          "answer": "Nagbibigay kami ng JSON configuration export, na nagpapahintulot sa iyo na i-save ang iyong resume settings sa JSON format, na maa-access anumang oras, saanman, sa anumang device."
+        },
+        {
+          "question": "Gaano ito ka-customizable?",
+          "answer": "Nag-aalok kami ng maraming customization option, kabilang ang mga kulay, layout, at iba pa, na nagpapahintulot sa iyo na i-adjust ang istilo ng iyong resume ayon sa personal na kagustuhan at pangangailangan ng industriya."
+        }
+      ]
+    }
+  },
+  "dashboard": {
+    "sidebar": {
+      "appName": "Magic Resume",
+      "resumes": "Mga Resume",
+      "settings": "Mga Setting",
+      "templates": "Mga Template",
+      "ai": "AI Config"
+    },
+    "resumes": {
+      "created": "Ginawa Noong",
+      "synced": "Mga Na-sync na File",
+      "view": "Tingnan",
+      "myResume": "Aking mga Resume",
+      "create": "Gumawa ng Resume",
+      "newResume": "Bagong Resume",
+      "newResumeDescription": "Gumawa ng bagong resume para magsimula.",
+      "import": "Mag-import ng Resume",
+      "untitled": "Walang Pamagat na Resume",
+      "importSuccess": "Matagumpay na na-import ang configuration",
+      "importError": "Nabigo ang import, pakisuri ang format ng file",
+      "importDialog": {
+        "title": "Mag-import ng Resume",
+        "jsonTitle": "Mag-import ng JSON",
+        "jsonDescription": "Mag-import ng na-export na resume config file (.json)",
+        "pdfTitle": "Mag-import ng PDF",
+        "pdfDescription": "Gamitin ang Gemini para gawing structured resume data",
+        "importing": "Nag-i-import, maghintay...",
+        "geminiConfigRequired": "Paki-configure muna ang Gemini API Key at Model ID sa AI settings",
+        "pdfSuccess": "Matagumpay na na-import ang PDF",
+        "pdfError": "Nabigo ang PDF import. Pakisuri ang PDF content o Gemini configuration"
+      },
+      "notice": {
+        "title": "Pansin",
+        "description": "Inirerekomenda na mag-configure ng resume backup folder sa settings para hindi mawala ang iyong data kapag na-clear ang browser cache",
+        "goToSettings": "Pumunta sa Settings"
+      },
+      "deleteConfirmTitle": "Kumpirmahin ang Pagtanggal ng Resume?",
+      "deleteConfirmDescription": "Hindi na ito maaaring ibalik. Permanenteng tatanggalin nito ang resume na ito at aalisin ang data mula sa iyong device.",
+      "createDialog": {
+        "title": "Gumawa ng Bagong Resume",
+        "description": "Magsimula ng bagong resume mula sa blank template",
+        "tabs": {
+          "fromTemplate": "Mula sa Template",
+          "uploadFile": "Mag-upload ng File"
+        },
+        "namePlaceholder": "Pangalan",
+        "switchTemplate": "Palitan ang Template",
+        "cancel": "Kanselahin",
+        "create": "Gumawa",
+        "blankTitle": "Blank Resume",
+        "startFromBlank": "Magsimula sa Blank",
+        "startFromTemplate": "Magsimula sa Template",
+        "blankCardDescription": "Gumamit ng default built-in layout at magsimula mula sa simula.",
+        "blankThumbnailDescription": "Magsimula sa malinis na pahina at hubugin ang code-driven resume na may kumpletong creative control.",
+        "createNow": "Gumawa Ngayon",
+        "backToGrid": "Bumalik sa template grid",
+        "blankPreviewDescription": "Pumili ng blank page at buuin ang lahat mula sa zero, walang preset constraints.",
+        "useThisTemplate": "Gamitin ang Template na Ito",
+        "sample": {
+          "company": "Google",
+          "position": "Senior Software Engineer",
+          "present": "Kasalukuyan",
+          "workDescription": "Nanguna sa frontend team at pinabuti ang page performance ng 40%."
+        }
+      }
+    },
+    "settings": {
+      "title": "Mga Setting",
+      "syncDirectory": {
+        "title": "Sync Directory",
+        "description": "Pumili ng folder para i-sync at i-backup ang iyong mga resume.",
+        "currentSyncFolder": "Kasalukuyang Sync Folder",
+        "noFolderConfigured": "Walang naka-configure na folder",
+        "changeFolder": "Palitan ang Folder",
+        "selectFolder": "Pumili ng Folder"
+      },
+      "sync": {
+        "title": "Sync Directory",
+        "description": "Pumili ng folder para i-sync at i-backup ang iyong mga resume.",
+        "select": "Pumili ng Folder"
+      },
+      "ai": {
+        "title": "AI Configuration",
+        "currentModel": "Kasalukuyang Model",
+        "selectModel": "Pumili ng Model",
+        "getApiKey": "Kumuha ng API Key",
+        "doubao": {
+          "title": "Doubao",
+          "description": "Kumuha ng API key mula sa Volcengine",
+          "apiKey": "Doubao API Key",
+          "modelId": "Model ID"
+        },
+        "deepseek": {
+          "title": "DeepSeek",
+          "description": "Kumuha ng API key mula sa DeepSeek Platform",
+          "apiKey": "DeepSeek API Key"
+        },
+        "openai": {
+          "title": "OpenAI",
+          "description": "Kunin ang API key sa OpenAI o open platform na compatible sa OpenAI format",
+          "apiKey": "OpenAI API Key",
+          "modelId": "Model ID",
+          "apiEndpoint": "API Endpoint, halimbawa: https://openai.example.org/v1"
+        },
+        "gemini": {
+          "title": "Gemini",
+          "description": "May suporta sa polish, grammar check, at PDF image resume import. Inirerekomendang model: gemini-flash-latest",
+          "apiKey": "Gemini API Key",
+          "modelId": "Gemini Model ID"
+        }
+      }
+    },
+    "templates": {
+      "title": "Mga Template",
+      "useTemplate": "Gamitin ang Template",
+      "preview": "Preview",
+      "switchTemplate": "Palitan ang Template",
+      "classic": {
+        "name": "Classic",
+        "description": "Tradisyonal at minimalist na layout, angkop sa karamihan ng job applications"
+      },
+      "modern": {
+        "name": "Dalawang Column",
+        "description": "Classic two-column layout, nagha-highlight ng personal na katangian"
+      },
+      "leftRight": {
+        "name": "Section Title Background",
+        "description": "Kapansin-pansing section titles na may background color"
+      },
+      "timeline": {
+        "name": "Timeline Layout",
+        "description": "Timeline style, binibigyang-diin ang chronological order ng mga karanasan"
+      },
+      "minimalist": {
+        "name": "Minimalist",
+        "description": "Maraming whitespace, malinis at purong layout style"
+      },
+      "elegant": {
+        "name": "Elegant",
+        "description": "Centered title single-column design, may kaunting elegansya"
+      },
+      "creative": {
+        "name": "Creative",
+        "description": "Visual contrast design, masigla at personalized"
+      },
+      "editorial": {
+        "name": "Editorial",
+        "description": "Marangyang pinagsamang bold serif at refined sans-serif typography"
+      },
+      "swiss": {
+        "name": "Swiss Aesthetic",
+        "description": "Artistic Bauhaus layout na may malakas na typographic hierarchy at geometric accents, nagpapakita ng modern minimalism"
+      }
+    }
+  },
+  "pdfExport": {
+    "modal": {
+      "title": "I-export ang Resume",
+      "subtitle": "Piliin ang format na gusto mong i-export ang iyong resume",
+      "pdfDesc": "Mataas na precision rendering na may 100% format accuracy. Inirerekomenda para sa job applications.",
+      "printDesc": "I-save sa pamamagitan ng system print dialog. Gamitin bilang fallback o para sa custom margins.",
+      "jsonDesc": "I-export ang iyong resume data bilang JSON para sa backup o paglipat sa ibang device.",
+      "markdownDesc": "I-convert sa plain Markdown text para madaling ibahagi sa AI models.",
+      "privacyNotice": "Ipinapangako ng Magic Resume na hindi kailanman kokolektahin, i-u-upload, o iiimbak ang anumang resume data mo. Ganap na protektado ang iyong privacy."
+    },
+    "button": {
+      "export": "I-export",
+      "exportPdf": "I-export ang PDF (Server)",
+      "exportJson": "I-export ang JSON Config",
+      "exportMarkdown": "I-export ang Markdown",
+      "exporting": "Nag-e-export...",
+      "exportingJson": "Nag-e-export...",
+      "exportingMarkdown": "Nag-e-export...",
+      "print": "Browser Print"
+    },
+    "toast": {
+      "success": "Matagumpay na na-export ang PDF",
+      "error": "Nabigo ang PDF export",
+      "jsonSuccess": "Matagumpay na na-export ang configuration",
+      "jsonError": "Nabigo ang configuration export",
+      "markdownSuccess": "Matagumpay na na-export ang Markdown",
+      "markdownError": "Nabigo ang Markdown export"
+    }
+  },
+  "previewDock": {
+    "switchTemplate": "Palitan ang Template",
+    "grammarCheck": {
+      "idle": "AI Grammar Check",
+      "checking": "Sinusuri...",
+      "configurePrompt": "Paki-configure ang AI Model",
+      "configureButton": "I-configure",
+      "errorToast": "Nabigo ang grammar check, subukan muli"
+    },
+    "sidePanel": {
+      "expand": "I-expand ang Side Panel",
+      "collapse": "I-collapse ang Side Panel"
+    },
+    "editPanel": {
+      "expand": "I-expand ang Edit Panel",
+      "collapse": "I-collapse ang Edit Panel"
+    },
+    "previewPanel": {
+      "expand": "I-expand ang Preview Panel",
+      "collapse": "I-collapse ang Preview Panel"
+    },
+    "github": "GitHub",
+    "backToDashboard": "Bumalik sa Dashboard",
+    "copyResume": {
+      "tooltip": "Kopyahin ang Resume",
+      "success": "Matagumpay na nakopya ang resume",
+      "error": "Nabigo ang pagkopya ng resume"
+    },
+    "export": {
+      "tooltip": "I-export ang Resume",
+      "pdf": "I-export ang PDF",
+      "json": "I-export ang JSON",
+      "markdown": "I-export ang Markdown",
+      "print": "I-print"
+    },
+    "autoOnePage": {
+      "tooltip": "Auto Fit One Page",
+      "enabled": "Naka-enable ang one page mode",
+      "disabled": "Naka-disable ang one page mode",
+      "cannotFit": "Masyadong maraming content. Na-optimize hangga't maaari ngunit hindi magkasya sa isang pahina. Subukang gawing simple ang content o i-adjust ang margins at font size sa sidebar."
+    },
+    "backup": {
+      "configured": "Na-back up",
+      "notConfigured": "Hindi pa na-back up",
+      "clickToConfigure": "I-click para i-configure"
+    }
+  },
+  "workbench": {
+    "sidePanel": {
+      "layout": {
+        "title": "Layout",
+        "addCustomSection": "Magdagdag ng Module",
+        "addCustomSectionOption": "Magdagdag ng Custom Section",
+        "standardSections": {
+          "skills": "Mga Kasanayan",
+          "experience": "Karanasan",
+          "projects": "Mga Proyekto",
+          "education": "Edukasyon",
+          "selfEvaluation": "Sariling Pagsusuri",
+          "certificates": "Mga Sertipiko"
+        }
+      },
+      "theme": {
+        "title": "Kulay ng Tema",
+        "custom": "Custom"
+      },
+      "typography": {
+        "title": "Typography",
+        "font": {
+          "title": "Font",
+          "alibaba": "Alibaba PuHuiTi",
+          "misans": "MiSans",
+          "notosanssc": "Noto Sans SC",
+          "sourcehanserifsc": "Source Han Serif SC",
+          "note": "Ginagamit ang MiSans sa ilalim ng libreng commercial license nito. Panatilihin ang MiSans attribution kapag ipinamamahagi ang proyektong ito."
+        },
+        "lineHeight": {
+          "title": "Line Height",
+          "normal": "Default",
+          "relaxed": "Relaxed",
+          "loose": "Loose"
+        },
+        "baseFontSize": {
+          "title": "Base Font Size"
+        },
+        "headerSize": {
+          "title": "Section Header Size"
+        },
+        "subheaderSize": {
+          "title": "Subsection Header Size"
+        }
+      },
+      "spacing": {
+        "title": "Spacing",
+        "pagePadding": {
+          "title": "Page Padding"
+        },
+        "sectionSpacing": {
+          "title": "Section Spacing"
+        },
+        "paragraphSpacing": {
+          "title": "Paragraph Spacing"
+        }
+      },
+      "mode": {
+        "title": "Mode",
+        "useIconMode": {
+          "title": "Icon Mode"
+        },
+        "centerSubtitle": {
+          "title": "I-center ang Subtitle"
+        },
+        "flexibleHeaderLayout": {
+          "title": "Mahabang Pamagat"
+        }
+      }
+    },
+    "basicPanel": {
+      "title": "Profile",
+      "avatar": "Avatar",
+      "basicField": "Basic",
+      "customField": "Custom",
+      "layout": "Align",
+      "customFields": {
+        "placeholders": {
+          "label": "Label",
+          "value": "Halaga"
+        },
+        "displayLabel": "Ipakita ang label",
+        "addButton": "Magdagdag ng Custom Field"
+      },
+      "basicFields": {
+        "name": "Pangalan",
+        "title": "Pamagat",
+        "email": "Email",
+        "phone": "Telepono",
+        "website": "Website",
+        "location": "Lokasyon",
+        "birthDate": "Petsa ng Kapanganakan",
+        "employementStatus": "Trabaho"
+      },
+      "fieldVisibility": {
+        "show": "Ipakita",
+        "hide": "Itago"
+      },
+      "githubContributions": "GitHub Contributions"
+    },
+    "experiencePanel": {
+      "title": "Karanasan sa Trabaho",
+      "addButton": "Magdagdag ng Karanasan sa Trabaho",
+      "defaultProject": {
+        "company": "Tech Company Ltd.",
+        "position": "Senior Frontend Engineer",
+        "date": "2020 - Kasalukuyan",
+        "details": "Responsable sa core product development..."
+      },
+      "placeholders": {
+        "company": "pangalan ng kumpanya",
+        "position": "job title",
+        "date": "panahon ng trabaho",
+        "details": "mga responsibilidad at tagumpay sa trabaho"
+      }
+    },
+    "experienceItem": {
+      "labels": {
+        "company": "Pangalan ng Kumpanya",
+        "position": "Posisyon",
+        "date": "Panahon ng Trabaho",
+        "details": "Mga Responsibilidad sa Trabaho"
+      },
+      "placeholders": {
+        "company": "Ilagay ang pangalan ng kumpanya",
+        "position": "hal., Frontend Engineer",
+        "date": "hal., 2020-Kasalukuyan",
+        "details": "Ilarawan ang iyong mga responsibilidad at tagumpay sa role na ito"
+      },
+      "buttons": {
+        "edit": "I-edit",
+        "save": "I-save",
+        "cancel": "Kanselahin",
+        "delete": "Tanggalin"
+      },
+      "visibility": {
+        "show": "Ipakita",
+        "hide": "Itago"
+      }
+    },
+    "projectPanel": {
+      "title": "Karanasan sa Proyekto",
+      "addButton": "Magdagdag ng Proyekto",
+      "defaultProject": {
+        "name": "Personal na Proyekto",
+        "description": "Paglalarawan ng Proyekto",
+        "role": "Mga Responsibilidad",
+        "date": "2023.01 - 2023.06"
+      },
+      "placeholders": {
+        "name": "Pangalan ng Proyekto",
+        "description": "Maikling ilarawan ang background at layunin ng proyekto",
+        "role": "Ang iyong role at responsibilidad sa proyekto",
+        "date": "Saklaw ng oras ng proyekto",
+        "link": "Link ng proyekto "
+      }
+    },
+    "projectItem": {
+      "labels": {
+        "name": "Pangalan ng Proyekto",
+        "role": "Role sa Proyekto",
+        "date": "Panahon ng Proyekto",
+        "description": "Paglalarawan ng Proyekto",
+        "technologies": "Tech Stack",
+        "link": "Link ng Proyekto",
+        "linkLabel": "Display Text"
+      },
+      "placeholders": {
+        "name": "Ilagay ang pangalan ng proyekto",
+        "role": "Ang iyong role sa proyekto",
+        "date": "Saklaw ng oras ng proyekto",
+        "description": "Maikling ilarawan ang background at layunin ng proyekto",
+        "technologies": "Mga teknolohiya at tool na ginamit",
+        "link": "Link ng proyekto",
+        "linkLabel": "Display text"
+      },
+      "hints": {
+        "linkLabel": "Kung walang display text, awtomatikong ipapakita ang domain o buong URL. Tanging http:// at https:// links ang suportado."
+      },
+      "buttons": {
+        "edit": "I-edit",
+        "save": "I-save",
+        "cancel": "Kanselahin",
+        "delete": "Tanggalin"
+      },
+      "visibility": {
+        "show": "Ipakita",
+        "hide": "Itago"
+      }
+    },
+    "educationPanel": {
+      "title": "Edukasyon",
+      "addButton": "Magdagdag ng Edukasyon",
+      "defaultProject": {
+        "school": "Pangalan ng Paaralan",
+        "degree": "Degree",
+        "major": "Major",
+        "date": "2020.09 - 2024.06"
+      },
+      "placeholders": {
+        "school": "Ilagay ang pangalan ng paaralan",
+        "degree": "Pumili ng degree",
+        "major": "Ilagay ang major",
+        "date": "Ilagay ang panahon ng pag-aaral"
+      }
+    },
+    "educationItem": {
+      "labels": {
+        "school": "Pangalan ng Paaralan",
+        "degree": "Degree",
+        "major": "Major",
+        "date": "Panahon ng Pag-aaral",
+        "description": "Paglalarawan",
+        "gpa": "GPA",
+        "location": "Lokasyon",
+        "startDate": "Petsa ng Simula",
+        "endDate": "Petsa ng Pagtatapos"
+      },
+      "placeholders": {
+        "school": "Ilagay ang pangalan ng paaralan",
+        "degree": "Pumili ng degree",
+        "major": "Ilagay ang major",
+        "date": "Ilagay ang saklaw ng oras ng pag-aaral",
+        "description": "Ilagay ang paglalarawan ng paaralan",
+        "gpa": "Ilagay ang GPA",
+        "location": "Ilagay ang lokasyon"
+      },
+      "buttons": {
+        "edit": "I-edit",
+        "save": "I-save",
+        "cancel": "Kanselahin",
+        "delete": "Tanggalin"
+      },
+      "visibility": {
+        "show": "Ipakita",
+        "hide": "Itago"
+      }
+    },
+    "certificatesPanel": {
+      "title": "Mga Sertipiko",
+      "addButton": "Magdagdag ng Sertipiko",
+      "tips": "Mag-upload o mag-paste (Cmd/Ctrl + V) ng mga larawan nang direkta. I-adjust ang width ratio para sa horizontal layout.",
+      "width": "Lapad (%)",
+      "delete": "Tanggalin",
+      "empty": "Wala pang larawan. Mag-upload o mag-paste ng mga larawan."
+    }
+  },
+  "field": {
+    "selectDate": "Pumili ng Petsa",
+    "enterYear": "Ilagay ang Taon",
+    "toPresent": "Hanggang Kasalukuyan"
+  },
+  "richEditor": {
+    "bold": "Bold",
+    "italic": "Italic",
+    "underline": "Underline",
+    "link": "Link",
+    "linkPlaceholder": "Maglagay ng URL, halimbawa https://example.com",
+    "linkApply": "Ilapat",
+    "linkRemove": "Alisin",
+    "linkInvalid": "Maglagay ng wastong URL",
+    "textColor": "Kulay ng Text",
+    "backgroundColor": "Kulay ng Background",
+    "alignLeft": "I-align sa Kaliwa",
+    "alignCenter": "I-align sa Gitna",
+    "alignRight": "I-align sa Kanan",
+    "alignJustify": "I-justify",
+    "bulletList": "Bullet List",
+    "orderedList": "Ordered List",
+    "undo": "I-undo",
+    "redo": "I-redo",
+    "aiPolish": "AI Polish",
+    "paragraph": "Paragraph",
+    "heading1": "Heading 1",
+    "heading2": "Heading 2",
+    "heading3": "Heading 3",
+    "colors": {
+      "black": "Itim",
+      "darkGray": "Madilim na Gray",
+      "gray": "Gray",
+      "red": "Pula",
+      "orange": "Orange",
+      "orangeYellow": "Orange Yellow",
+      "yellow": "Dilaw",
+      "yellowGreen": "Yellow Green",
+      "green": "Berde",
+      "cyan": "Cyan",
+      "lightBlue": "Light Blue",
+      "blue": "Asul",
+      "purple": "Purple",
+      "magenta": "Magenta",
+      "pink": "Pink"
+    }
+  },
+  "iconSelector": {
+    "all": "Lahat",
+    "searchPlaceholder": "Maghanap ng mga icon...",
+    "noMatchingIcons": "Walang nahanap na katugmang icon",
+    "tryOtherKeywords": "Subukan ang ibang search keyword",
+    "selectOtherCategory": "Pumili ng ibang kategorya",
+    "categories": {
+      "personal": "Personal na Impormasyon",
+      "education": "Edukasyon",
+      "experience": "Karanasan sa Trabaho",
+      "skills": "Mga Kasanayan",
+      "languages": "Mga Wika",
+      "projects": "Mga Proyekto",
+      "achievements": "Mga Tagumpay",
+      "hobbies": "Mga Libangan",
+      "social": "Social Media",
+      "others": "Iba pa"
+    },
+    "icons": {
+      "user": "User",
+      "email": "Email",
+      "phone": "Telepono",
+      "address": "Address",
+      "website": "Website",
+      "mobile": "Mobile",
+      "education": "Edukasyon",
+      "school": "Paaralan",
+      "major": "Major",
+      "library": "Library",
+      "scholarship": "Scholarship",
+      "work": "Trabaho",
+      "company": "Kumpanya",
+      "office": "Opisina",
+      "dateRange": "Saklaw ng Petsa",
+      "workTime": "Oras ng Trabaho",
+      "programming": "Programming",
+      "system": "System",
+      "database": "Database",
+      "terminal": "Terminal",
+      "techStack": "Tech Stack",
+      "language": "Wika",
+      "speaking": "Pagsasalita",
+      "communication": "Komunikasyon",
+      "project": "Proyekto",
+      "branch": "Branch",
+      "release": "Release",
+      "target": "Target",
+      "trophy": "Trophy",
+      "medal": "Medal",
+      "star": "Star",
+      "interest": "Interes",
+      "music": "Musika",
+      "art": "Sining",
+      "photography": "Photography",
+      "linkedin": "LinkedIn",
+      "twitter": "Twitter",
+      "facebook": "Facebook",
+      "instagram": "Instagram",
+      "profile": "Profile",
+      "review": "Review",
+      "filter": "Filter",
+      "link": "Link",
+      "salary": "Sahod",
+      "idea": "Ideya",
+      "send": "Ipadala",
+      "share": "Ibahagi",
+      "settings": "Mga Setting",
+      "search": "Maghanap",
+      "flag": "Flag",
+      "bookmark": "Bookmark",
+      "thumbsUp": "Thumbs Up",
+      "skill": "Kasanayan"
+    }
+  },
+  "aiPolishDialog": {
+    "title": "AI Polish",
+    "description": {
+      "ready": "Magdagdag ng opsyonal na tagubilin, pagkatapos i-click ang \"Simulan ang polish\"",
+      "polishing": "Pinapapaganda ang iyong content...",
+      "finished": "Na-optimize na ang content, pakisuri ang resulta"
+    },
+    "error": {
+      "configRequired": "Paki-configure muna ang AI model",
+      "polishFailed": "Nabigo ang polish",
+      "applied": "Na-apply ang polished content"
+    },
+    "content": {
+      "original": "Orihinal na Content",
+      "polished": "Polished na Content"
+    },
+    "customInstructions": "Custom na tagubilin",
+    "customInstructionsPlaceholder": "hal. Gumamit ng mas teknikal na termino, i-highlight ang metrics, panatilihing pormal ang tono… (opsyonal)",
+    "button": {
+      "start": "Simulan ang polish",
+      "regenerate": "I-regenerate",
+      "generating": "Gumagawa...",
+      "apply": "Ilapat ang Content"
+    }
+  },
+  "photoConfig": {
+    "title": "Mga Setting ng Larawan",
+    "description": "I-customize ang larawan ng iyong resume",
+    "upload": {
+      "title": "Online Link",
+      "dragHint": "I-drag and drop o i-click para mag-upload ng larawan",
+      "sizeLimit": "Hindi dapat lumampas sa 2MB ang laki ng larawan",
+      "typeLimit": "Mag-upload ng image file",
+      "urlPlaceholder": "Ilagay ang link ng larawan",
+      "invalidUrl": "Hindi wasto ang image URL o hindi ma-access, subukan ang ibang link ng larawan",
+      "timeout": "Nag-timeout ang paglo-load",
+      "loadError": "Nabigo ang paglo-load ng larawan"
+    },
+    "config": {
+      "aspectRatio": "Aspect Ratio",
+      "size": "Laki",
+      "width": "Lapad",
+      "height": "Taas",
+      "border-radius": "Border Radius",
+      "widthPlaceholder": "Lapad",
+      "heightPlaceholder": "Taas",
+      "ratios": {
+        "1:1": "1:1 Square",
+        "4:3": "4:3 Landscape",
+        "3:4": "3:4 Portrait",
+        "16:9": "16:9 Widescreen",
+        "custom": "Custom"
+      },
+      "borderRadius": {
+        "none": "Wala",
+        "medium": "Medium",
+        "full": "Bilog",
+        "custom": "Custom",
+        "customPlaceholder": "Custom border radius"
+      }
+    },
+    "actions": {
+      "reset": "I-reset",
+      "close": "Isara",
+      "cancel": "Kanselahin",
+      "removePhoto": "Alisin ang Larawan"
+    }
+  },
+  "templates": {
+    "switchTemplate": "Palitan ang Template"
+  },
+  "themeModal": {
+    "delete": {
+      "title": "Kumpirmahin ang Pagtanggal",
+      "description": "Sigurado ka bang gusto mong tanggalin ang {title}?",
+      "confirmText": "Tanggalin",
+      "cancelText": "Kanselahin"
+    }
+  },
+  "grammarCheck": {
+    "title": "AI Grammar Check",
+    "description": "Nakahanap ng {count} mungkahi",
+    "exit": "Lumabas",
+    "spelling": "Spelling",
+    "punctuation": "Bantas",
+    "original": "Orihinal",
+    "error_point": "Error",
+    "suggestion": "Mungkahi",
+    "reason": "Dahilan",
+    "accept": "Ilapat",
+    "ignore": "Balewalain",
+    "found_issues": "Nakahanap ng {count} isyu",
+    "applied_success": "Na-apply ang mga pagbabago",
+    "apply_error": "Hindi nahanap ang text, hindi awtomatikong maia-apply",
+    "no_errors_title": "Perpekto!",
+    "no_errors_desc": "Walang nahanap na grammar o punctuation error."
+  },
+  "faqDialog": {
+    "title": "Mga Madalas Itanong (FAQ)",
+    "description": "Mga karaniwang tip at solusyon para sa Magic Resume workbench.",
+    "items": {
+      "browser-compatibility": {
+        "question": "Anong browser ang inirerekomenda?",
+        "answer": "Inirerekomenda naming gamitin ang pinakabagong bersyon ng Chrome o Edge para sa pinakamahusay na layout at export experience. Maaaring magdulot ng styling issues ang ilang lumang browser."
+      },
+      "export-failure": {
+        "question": "Paano kung nabigo ang export o sira ang style?",
+        "answer": "1. Inirerekomenda naming gamitin ang Google Chrome (https://www.google.cn/intl/zh-CN/chrome/) para sa pinakamahusay na compatibility.\n2. Kung nabigo pa rin, subukan sa 'Incognito Mode' para maiwasan ang interference ng extension.\n3. Bilang alternatibo, i-click ang 'PDF (Backup)' sa export menu at piliin ang 'Save as PDF' sa print dialog."
+      },
+      "export-methods": {
+        "question": "Ano ang pagkakaiba ng dalawang export method?",
+        "answer": "• Export PDF: Gumagamit ng backend service para sa high-precision rendering, 100% na nire-restore ang layout. Inirerekomenda para sa pormal na pagsusumite sa HR.\n\n• Browser Print: Tinatawag ang native print function ng iyong browser (Save as PDF). Angkop kapag abala ang backend export service o kailangan mong i-fine-tune ang print margins sa browser."
+      },
+      "drag-and-drop": {
+        "question": "Paano i-drag and drop para i-reorder ang mga module?",
+        "answer": "Sa 'Layout' settings ng left edit panel, i-hover ang cursor sa 'Drag Handle' (karaniwang six-dot icon) sa kaliwang bahagi ng module card. I-click at hawakan ang left mouse button para i-drag ang module pataas o pababa para i-reorder ang mga section ng iyong resume."
+      }
+    }
+  }
+}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1,0 +1,19 @@
+import type { Locale } from "./config";
+import zh from "./locales/zh.json";
+import en from "./locales/en.json";
+import tl from "./locales/tl.json";
+
+export const messagesByLocale: Record<Locale, typeof zh> = {
+  zh,
+  en,
+  tl,
+};
+
+export const getMessagesForLocale = (locale: Locale) =>
+  messagesByLocale[locale] ?? messagesByLocale.zh;
+
+export const localeOgTags: Record<Locale, string> = {
+  zh: "zh_CN",
+  en: "en_US",
+  tl: "fil_PH",
+};

--- a/src/lib/templatePreview.ts
+++ b/src/lib/templatePreview.ts
@@ -1,8 +1,5 @@
 import { DEFAULT_TEMPLATES } from "@/config";
-import {
-  initialResumeState,
-  initialResumeStateEn,
-} from "@/config/initialResumeData";
+import { initialResumeByLocale } from "@/i18n/localeContent";
 import type { ResumeData } from "@/types/resume";
 import type { ResumeTemplate } from "@/types/template";
 
@@ -12,14 +9,15 @@ export const TEMPLATE_SNAPSHOT_VERSION = 1;
 export const TEMPLATE_SNAPSHOT_ROOT_ATTRIBUTE = "data-template-snapshot-root";
 export const TEMPLATE_SNAPSHOT_ROOT_SELECTOR = `[${TEMPLATE_SNAPSHOT_ROOT_ATTRIBUTE}]`;
 export const TEMPLATE_SNAPSHOT_PUBLIC_DIR = "template-snapshots";
-export const TEMPLATE_PREVIEW_LOCALES = ["zh", "en"] as const;
+export const TEMPLATE_PREVIEW_LOCALES = ["zh", "en", "tl"] as const;
 
 export type TemplatePreviewLocale = (typeof TEMPLATE_PREVIEW_LOCALES)[number];
 
 export interface TemplateSnapshotManifest {
   version: number;
   generatedAt: string | null;
-  locales: Record<TemplatePreviewLocale, Record<string, string>>;
+  locales: Partial<Record<TemplatePreviewLocale, Record<string, string>>> &
+    Record<"zh" | "en", Record<string, string>>;
 }
 
 export const createEmptyTemplateSnapshotManifest =
@@ -29,20 +27,21 @@ export const createEmptyTemplateSnapshotManifest =
     locales: {
       zh: {},
       en: {},
+      tl: {},
     },
   });
 
 export const isTemplatePreviewLocale = (
   value: string | null | undefined
 ): value is TemplatePreviewLocale =>
-  value === "zh" || value === "en";
+  value === "zh" || value === "en" || value === "tl";
 
 export const getTemplateById = (templateId: string | undefined): ResumeTemplate =>
   DEFAULT_TEMPLATES.find((template) => template.id === templateId) ??
   DEFAULT_TEMPLATES[0];
 
 export const getTemplatePreviewBaseData = (locale: TemplatePreviewLocale) =>
-  locale === "en" ? initialResumeStateEn : initialResumeState;
+  initialResumeByLocale[locale];
 
 export const createTemplatePreviewData = (
   template: ResumeTemplate,
@@ -79,4 +78,7 @@ export const getTemplateSnapshotSrc = (
   manifest: TemplateSnapshotManifest,
   locale: TemplatePreviewLocale,
   templateId: string
-) => manifest.locales[locale][templateId] ?? null;
+) =>
+  manifest.locales[locale]?.[templateId] ??
+  (locale === "tl" ? manifest.locales.en?.[templateId] : null) ??
+  null;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,5 +4,5 @@ import { routing } from "./i18n/routing.public";
 export default createMiddleware(routing);
 
 export const config = {
-  matcher: ["/", "/(zh|en)/:path*"]
+  matcher: ["/", "/(zh|en|tl)/:path*"]
 };

--- a/src/routes/$locale.tsx
+++ b/src/routes/$locale.tsx
@@ -1,8 +1,10 @@
 import { createFileRoute, notFound } from "@tanstack/react-router";
 import LandingPage from "@/app/(public)/[locale]/page";
 import { defaultLocale, locales, type Locale } from "@/i18n/config";
-import zhMessages from "@/i18n/locales/zh.json";
-import enMessages from "@/i18n/locales/en.json";
+import {
+  getMessagesForLocale,
+  localeOgTags,
+} from "@/i18n/messages";
 
 const SEO_BASE_URL = "https://magicv.art";
 
@@ -14,19 +16,19 @@ function resolveLocale(rawLocale: string): Locale {
 }
 
 function getLocaleSeo(locale: Locale) {
-  const messages = locale === "en" ? enMessages : zhMessages;
+  const messages = getMessagesForLocale(locale);
   const title = `${messages.common.title} - ${messages.common.subtitle}`;
   const description = messages.common.description;
-  const localeTag = locale === "en" ? "en_US" : "zh_CN";
+  const localeTag = localeOgTags[locale];
   const canonical = `${SEO_BASE_URL}/${locale}`;
-  const alternateLocale = locale === "en" ? "zh" : "en";
+  const alternateLocales = locales.filter((l) => l !== locale);
 
   return {
     title,
     description,
     localeTag,
     canonical,
-    alternateLocale
+    alternateLocales,
   };
 }
 
@@ -55,11 +57,11 @@ export const Route = createFileRoute("/$locale")({
       links: [
         { rel: "canonical", href: seo.canonical },
         { rel: "alternate", hrefLang: locale, href: seo.canonical },
-        {
-          rel: "alternate",
-          hrefLang: seo.alternateLocale,
-          href: `${SEO_BASE_URL}/${seo.alternateLocale}`
-        },
+        ...seo.alternateLocales.map((altLocale) => ({
+          rel: "alternate" as const,
+          hrefLang: altLocale,
+          href: `${SEO_BASE_URL}/${altLocale}`,
+        })),
         { rel: "alternate", hrefLang: "x-default", href: `${SEO_BASE_URL}/zh` }
       ]
     };

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -10,8 +10,7 @@ import appFontCss from "../app/font.css?url";
 import tiptapCss from "../styles/tiptap.scss?url";
 import { NextIntlClientProvider } from "@/i18n/compat/client";
 import { useEffect } from "react";
-import zhMessages from "@/i18n/locales/zh.json";
-import enMessages from "@/i18n/locales/en.json";
+import { getMessagesForLocale } from "@/i18n/messages";
 import { Providers } from "@/app/providers";
 import { Toaster } from "@/components/ui/sonner";
 import { getPreferredLocale } from "@/i18n/runtime";
@@ -69,7 +68,7 @@ function RootComponent() {
     select: (location) => location.pathname
   });
   const locale = getPreferredLocale(pathname);
-  const messages = locale === "en" ? enMessages : zhMessages;
+  const messages = getMessagesForLocale(locale);
 
   useEffect(() => {
     document.cookie = `NEXT_LOCALE=${locale}; path=/; max-age=31536000`;

--- a/src/store/useResumeStore.ts
+++ b/src/store/useResumeStore.ts
@@ -15,11 +15,12 @@ import {
 } from "../types/resume";
 import { DEFAULT_TEMPLATES } from "@/config";
 import {
-  initialResumeState,
-  initialResumeStateEn,
-  blankResumeState,
-  blankResumeStateEn,
-} from "@/config/initialResumeData";
+  blankResumeByLocale,
+  copyLabelByLocale,
+  defaultResumeTitleByLocale,
+  initialResumeByLocale,
+  resolveLocaleFromCookie,
+} from "@/i18n/localeContent";
 import { generateUUID } from "@/utils/uuid";
 import {
   HISTORY_LIMIT,
@@ -293,22 +294,18 @@ export const useResumeStore = create(
       future: {},
 
       createResume: (templateId = null, isBlank = false) => {
-        const locale =
+        const locale = resolveLocaleFromCookie(
           typeof document !== "undefined"
             ? document.cookie
                 .split("; ")
                 .find((row) => row.startsWith("NEXT_LOCALE="))
-                ?.split("=")[1] || "zh"
-            : "zh";
+                ?.split("=")[1]
+            : undefined
+        );
 
-        let initialResumeData: any;
-        if (isBlank) {
-          initialResumeData =
-            locale === "en" ? blankResumeStateEn : blankResumeState;
-        } else {
-          initialResumeData =
-            locale === "en" ? initialResumeStateEn : initialResumeState;
-        }
+        const initialResumeData = isBlank
+          ? blankResumeByLocale[locale]
+          : initialResumeByLocale[locale];
 
         const id = generateUUID();
         const template = templateId
@@ -321,7 +318,7 @@ export const useResumeStore = create(
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
           templateId: template?.id,
-          title: `${locale === "en" ? "New Resume" : "新建简历"} ${id.slice(
+          title: `${defaultResumeTitleByLocale[locale]} ${id.slice(
             0,
             6
           )}`,
@@ -553,20 +550,19 @@ export const useResumeStore = create(
         }
 
         // 获取当前语言环境
-        const locale =
+        const locale = resolveLocaleFromCookie(
           typeof document !== "undefined"
             ? document.cookie
                 .split("; ")
                 .find((row) => row.startsWith("NEXT_LOCALE="))
-                ?.split("=")[1] || "zh"
-            : "zh";
+                ?.split("=")[1]
+            : undefined
+        );
 
         const duplicatedResume = {
           ...structuredClone(originalResume),
           id: newId,
-          title: `${originalResume.title} (${
-            locale === "en" ? "Copy" : "复制"
-          })`,
+          title: `${originalResume.title} (${copyLabelByLocale[locale]})`,
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
         };


### PR DESCRIPTION
Introduces full Filipino/Tagalog (tl) localization to enhance accessibility and improve the experience for Filipino users. This update expands language coverage across the app’s internationalization system.

🚀 New
- Added tl locale with translated UI strings
- Registered the new locale in the i18n configuration
- Synced translation keys with the current English baseline

🔧 Improvements
- Ensures consistent fallback behavior for untranslated keys
- Maintains alignment with existing locale structure for easier future updates